### PR TITLE
Rearrange config handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /uploads
 __pycache__
 *.pyc
+
+# This file is for local config which we never want committed:
+/sogs/config.py

--- a/convert-privkey.py
+++ b/convert-privkey.py
@@ -9,7 +9,7 @@ from sogs import config
 with open('x25519_private_key.pem') as f:
     pkey_pem = f.read()
 
-if os.path.exists(config.SEED_FILE):
+if os.path.exists(config.KEY_FILE):
     print("Error: {} already exists, not overwriting it!", file=sys.stderr)
 
 key = c.load_privatekey(c.FILETYPE_PEM, pkey_pem).to_cryptography_key()
@@ -17,7 +17,7 @@ pubkey_hex = key.public_key().public_bytes(encoding=s.Encoding.Raw, format=s.Pub
 
 print("Loaded private key; associated pubkey: {}".format(pubkey_hex))
 
-with open(config.SEED_FILE, 'wb') as f:
+with open(config.KEY_FILE, 'wb') as f:
     f.write(
         key.private_bytes(
             encoding=s.Encoding.Raw,
@@ -26,4 +26,4 @@ with open(config.SEED_FILE, 'wb') as f:
         )
     )
 
-print("Wrote privkey to {}".format(config.SEED_FILE))
+print("Wrote privkey to {}".format(config.KEY_FILE))

--- a/sogs/base_config.py
+++ b/sogs/base_config.py
@@ -1,0 +1,55 @@
+import logging
+import re
+
+# STOP: Do not make changes to this file!  This file contains defaults for the open group server and
+# is intended to be replaced on upgrade.  If you want to override any changes you should instead set
+# the variable you care about in `config.py`, which overrides values specified here.
+
+# The paths we use for storage; if relative these are in the current working directory of the server
+# process running sogs.
+DB_PATH = 'sogs.db'
+DB_SCHEMA_FILE = 'schema.sql'
+KEY_FILE = 'key_x25519'
+
+# Base url for generating links.  Can be http, https, and may or may not include a port.  Note if
+# using https that you need to set up proper HTTPS certificates, for example using certbot to obtain
+# a free Let's Encrypt certificate.
+URL_BASE = 'http://example.net'
+
+# The log level.
+LOG_LEVEL = logging.WARNING
+
+# Default upload expiry time, in days.
+UPLOAD_DEFAULT_EXPIRY_DAYS = 15
+
+# We truncate filenames if the sanitized name (not including the initial 'ID_') is longer than this.
+UPLOAD_FILENAME_MAX = 60
+
+# When a filename exceeds UPLOAD_FILENAME_MAX, we keep this many characters from the beginning,
+# append "...", and then append enough from the end (i.e. max - this - 3) to hit the _MAX value.
+UPLOAD_FILENAME_KEEP_PREFIX = 40
+UPLOAD_FILENAME_KEEP_SUFFIX = 17
+
+# Maximum size of a file upload that we accept, in bytes.  Note that onion requests have a hard
+# limit of 10MB for a fully-wrapped request, and that Session uploads with base64 encoding,
+# so this is deliberately set conservatively below that limit.
+UPLOAD_FILE_MAX_SIZE = 6_000_000
+
+# Regex that matches *invalid* characters in a user-supplied filename (if any); any matches of this
+# regex get replaced with a single _ when writing the file to disk.  The default is intended to
+# strip out enough so that the filename is storable portably on modern OS filesystems.
+UPLOAD_FILENAME_BAD = re.compile(r"[^\w+\-.'()@\[\]]+")
+
+# How long without activity before we drop user-room activity info, in days.
+ROOM_ACTIVE_PRUNE_THRESHOLD = 60
+
+# The default user activity cutoff that is used to report a room's current "active users" count; the
+# unit is in days.
+ROOM_DEFAULT_ACTIVE_THRESHOLD = 7
+
+# How long we keep message edit/deletion history, in days.
+MESSAGE_HISTORY_PRUNE_THRESHOLD = 30
+
+# file containing "bad" words for filtration.  This feature in temporary and will be removed once
+# more robust bot/spam filtering is available.
+BAD_WORDS_FILE = 'badwords.txt'

--- a/sogs/config.py
+++ b/sogs/config.py
@@ -1,47 +1,5 @@
-import logging
-import re
+from .base_config import *
 
-DB_PATH = 'sogs.db'
-DB_SCHEMA_FILE = 'schema.sql'
-
-SEED_FILE = 'sogs-seed.bin'
-
-# base url for generating links
-URL_BASE = 'http://51.79.57.234:8000'
-
-LOG_LEVEL = logging.DEBUG
-
-# Default upload expiry, in days
-UPLOAD_DEFAULT_EXPIRY_DAYS = 15
-
-#  We truncate filenames if the sanitized name (not including the initial 'ID_') is longer than
-#  this.
-UPLOAD_FILENAME_MAX = 60
-
-# When a filename exceeds _MAX, we keep this much from the beginning, append ..., and then append
-# enough from the end (i.e. max - this - 3) to hit the _MAX value.
-UPLOAD_FILENAME_KEEP_PREFIX = 40
-UPLOAD_FILENAME_KEEP_SUFFIX = 17
-
-# Maximum size of a file upload that we accept, in bytes.  Note that onion requests have a hard
-# limit of 10MB for a fully-wrapped request, and that Session uploads with base64 encoding,
-# so this is deliberately set conservatively below that limit.
-UPLOAD_FILE_MAX_SIZE = 6_000_000
-
-# Regex that matches *invalid* characters in a user-supplied filename (if any); any matches of this
-# regex get replaced with a single _ when writing the file to disk.
-UPLOAD_FILENAME_BAD = re.compile(r"[^\w+\-.'()@\[\]]+")
-
-# How long without activity before we drop user-room activity info, in days
-ROOM_ACTIVE_PRUNE_THRESHOLD = 60
-
-# The default user activity cutoff that is used to report a room's current "active users" count; the
-# unit is in days.
-ROOM_DEFAULT_ACTIVE_THRESHOLD = 7
-
-# How long we keep message edit/deletion history, in days
-MESSAGE_HISTORY_PRUNE_THRESHOLD = 30
-
-
-# file containing "bad" words for filtration
-BAD_WORDS_FILE = 'badwords.txt'
+# Add any config overrides here.
+# (If running out of a git checkout you may want `git update-index --skip-worktree sogs/config.py`
+# to make git ignore changes you make here).

--- a/sogs/crypto.py
+++ b/sogs/crypto.py
@@ -15,11 +15,11 @@ import hmac
 import pyonionreq
 
 # generate seed as needed
-if not os.path.exists(config.SEED_FILE):
-    with open(config.SEED_FILE, 'wb') as f:
+if not os.path.exists(config.KEY_FILE):
+    with open(config.KEY_FILE, 'wb') as f:
         f.write(PrivateKey.generate().encode())
 
-with open(config.SEED_FILE, 'rb') as f:
+with open(config.KEY_FILE, 'rb') as f:
     _privkey = PrivateKey(f.read())
 
 server_pubkey = _privkey.public_key


### PR DESCRIPTION
This moves all the default configuration into a `base_config.py` and imports `*` from `config.py`.  `config.py` is thus intended to almost never change, and so can set whatever it wants to override the values from the base config with local overrides added to it without worrying about missing out on new config items that get added to the basic config.

Notes for current `dev` followers:
- the default seed file path changed to `key_x25519` (was `sogs-seed.bin`) to match how we store keys elsewhere in oxen stuff.  It also got renamed in the config to KEY_FILE because, for x25519 (unlike ed25519), this is the direct privkey value, not a seed.
- the base url is changed to example.net rather than some dev's IP.