### PR TITLE
Padding fix

### DIFF
--- a/sogs/migrate01x.py
+++ b/sogs/migrate01x.py
@@ -157,6 +157,13 @@ def migrate01x(conn):
                         data = utils.decode_base64(data)
                         data_size = len(data)
                         data = data.rstrip(b'\0')
+                        if len(data) >= 2 and data[-1] == 0x80:
+                            data = data[:-1]
+                        else:
+                            raise RuntimeError(
+                                "Unexpected data: {} message id={} didn't contain expected "
+                                "0x80 0x00... padding".format(room_db_path, id)
+                            )
 
                         # Signature was just base64 encoded:
                         signature = utils.decode_base64(signature)

--- a/sogs/migrate01x.py
+++ b/sogs/migrate01x.py
@@ -156,14 +156,7 @@ def migrate01x(conn):
                         # unpad it:
                         data = utils.decode_base64(data)
                         data_size = len(data)
-                        data = data.rstrip(b'\0')
-                        if len(data) >= 2 and data[-1] == 0x80:
-                            data = data[:-1]
-                        else:
-                            raise RuntimeError(
-                                "Unexpected data: {} message id={} didn't contain expected "
-                                "0x80 0x00... padding".format(room_db_path, id)
-                            )
+                        data = utils.remove_session_message_padding(data)
 
                         # Signature was just base64 encoded:
                         signature = utils.decode_base64(signature)

--- a/sogs/static/view_room.js
+++ b/sogs/static/view_room.js
@@ -34,7 +34,7 @@ const setup = async () => {
                 elem.appendChild(document.createTextNode(`the ${window.view_room} room is empty`));
             }
 
-            for(let msg of msgs)
+            for(let msg of msgs.reverse())
             {
                 let e = document.createElement("li")
                 try

--- a/sogs/static/view_room.js
+++ b/sogs/static/view_room.js
@@ -1,6 +1,14 @@
 
 const makebuffer = (raw) => {
-    return Uint8Array.from(window.atob(raw), (v) => v.charCodeAt(0));
+    let b = Uint8Array.from(window.atob(raw), (v) => v.charCodeAt(0));
+    // This data is padded with a 0x80 delimiter followed by any number of 0x00 bytes, but these are
+    // *not* part of the protocol buffer encoding, so we need to strip it off.
+    let realLength = b.length;
+    while (realLength > 0 && b[realLength-1] == 0)
+        realLength--;
+    if (realLength > 0 && b[realLength-1] == 0x80)
+        realLength--;
+    return b.subarray(0, realLength);
 };
 const setup = async () => {
     const elem = document.getElementById("messages");
@@ -31,7 +39,6 @@ const setup = async () => {
                 let e = document.createElement("li")
                 try
                 {
-                    console.log(msg);
                     const data = makebuffer(msg.data);
                     const err = Message.verify(data);
                     if(err)


### PR DESCRIPTION
Fixes issues related to padding:
- Session padding is actually 0x80 0x00..., so we now strip off the 0x80 as well (because if you *don't* strip it off it fails as a protocol buffer).
- But sometimes messages aren't padded because who knows, so also be bug-for-bug compatible with Session allowing that.

Mostly unrelated:
- reverse the displayed message on the summary page to put newer messages later, as Session and most messengers do.