### PR TITLE
Session stale token workaround

### DIFF
--- a/sogs/legacy_routes.py
+++ b/sogs/legacy_routes.py
@@ -214,7 +214,15 @@ def handle_comapct_poll():
         try:
             r = handle_one_compact_poll(req)
         except HTTPException as e:
-            r = {'status_code': e.get_response().status_code, 'results': []}
+            # Hack for Session: if there isn't a full fleshed out response then Session just ignores
+            # the response (even when it's an error response), so we send this fake response:
+            r = {
+                'status_code': e.get_response().status_code,
+                'room_id': req.get('room_id', ''),
+                'messages': [],
+                'deletions': [],
+                'moderators': [],
+            }
         result.append(r)
 
     return jsonify({'status_code': 200, 'results': result})


### PR DESCRIPTION
Session requires fields be present even for an error response, which
feels wrong, but is required to get current Session to properly request
a new token.