### PR TITLE
Redo how db.conn and transactions work

### DIFF
--- a/sogs/mule.py
+++ b/sogs/mule.py
@@ -1,4 +1,3 @@
-import uwsgi
 import traceback
 import oxenmq
 from oxenc import bt_deserialize
@@ -9,8 +8,7 @@ import functools
 from .web import app
 from . import cleanup
 from . import config
-from . import crypto
-from .omq import omq
+from . import omq as o
 
 # This is the uwsgi "mule" that handles things not related to serving HTTP requests:
 # - it holds the oxenmq instance (with its own interface into sogs)
@@ -42,7 +40,7 @@ def inproc_fail(connid, reason):
 
 
 def setup_omq():
-    global omq, mule_conn
+    omq = o.omq
 
     app.logger.debug("Mule setting up omq")
     if isinstance(config.OMQ_LISTEN, list):
@@ -73,7 +71,7 @@ def setup_omq():
     # Connect mule to itself so that if something the mule does wants to send something to the mule
     # it will work.  (And so be careful not to recurse!)
     app.logger.debug("Mule connecting to self")
-    mule_conn = omq.connect_inproc(on_success=None, on_failure=inproc_fail)
+    o.mule_conn = omq.connect_inproc(on_success=None, on_failure=inproc_fail)
 
 
 def log_exceptions(f):

--- a/sogs/omq.py
+++ b/sogs/omq.py
@@ -14,8 +14,8 @@ mule_conn = None
 def make_omq():
     omq = oxenmq.OxenMQ(privkey=crypto._privkey.encode(), pubkey=crypto.server_pubkey.encode())
 
-    # We have multiple workers talking to the mule, so we *must* use ephemeral ids to not replace each
-    # others' connections.
+    # We have multiple workers talking to the mule, so we *must* use ephemeral ids to not replace
+    # each others' connections.
     omq.ephemeral_routing_id = True
 
     return omq
@@ -44,7 +44,7 @@ def start_oxenmq():
     app.logger.debug(f"Starting oxenmq connection to mule in worker {uwsgi.worker_id()}")
 
     omq.start()
-    app.logger.debug(f"Started, connecting to mule")
+    app.logger.debug("Started, connecting to mule")
     mule_conn = omq.connect_remote(oxenmq.Address(config.OMQ_INTERNAL))
 
     app.logger.debug(f"worker {uwsgi.worker_id()} connected to mule OMQ")

--- a/sogs/routes.py
+++ b/sogs/routes.py
@@ -89,9 +89,9 @@ def get_recent_room_messages(room):
     limit = utils.get_int_param('limit', 100, min=1, max=256)
 
     msgs = list()
-    with db.conn as conn:
+    with db.tx() as cur:
         # FIXME: need to check user permissions here too
-        rows = conn.execute(
+        rows = cur.execute(
             """
             SELECT
                 messages.id, session_id, posted, edited, data, data_size, signature


### PR DESCRIPTION
- `db.conn` is now gone; instead we have `db.get_conn()` which returns a thread-local database connection that connects on first use, though this `db.get_conn()` typically isn't used directly in favour of the following.  The thread-local is needed because otherwise (on the bot api PR branch) the mule's cleanup timer would fail because sqlite connections aren't supposed to be used across threads.

- `db.cur()` returns a cursor on the current thread's database connection (connecting first, if necessary).  This doesn't start a transaction, and so is equivalent to places where we were directly executing on db.conn outside a transaction before.

- `db.execute()` is a wrapper around getting a cursor, executing on it, and then returning it (and is basically the drop-in replacement for `db.conn.execute(...)`).  As with db.cur(), this doesn't start a transaction.

- `with db.tx() as cur:` is roughly the same as the old code:

      with db.conn as conn:
          cur = conn.cursor()

  but with two differences: the thread-local connection (as above), and more significantly, it now implements savepoints on entry and savepoint release on exit (rather than using the built-in un-nestable sqlite context manager) so that we can safely nest transactions now.