### PR TITLE
DB transaction deadlock fix

### DIFF
--- a/sogs/db.py
+++ b/sogs/db.py
@@ -100,8 +100,8 @@ class LocalTxContextManager:
                     self.conn.execute("ROLLBACK")
                 else:
                     self.conn.execute(f"ROLLBACK TO SAVEPOINT sogs_sp_{self.sp_num}")
-            except Exception:
-                pass
+            except Exception as e:
+                logging.warn(f"Failed to rollback database transaction: {e}")
 
 
 # Shorter alias for convenience


### PR DESCRIPTION
Transactions were using `BEGIN DEFERRED` (implicitly, by starting a `SAVEPOINT`, which is always `BEGIN DEFERRED`).  This created a race condition because:

- thread 1 BEGINs a transaction, does read-only query (and so has a read lock).
- thread 2 BEGINs a transaction, does a read-only query (and so has a read lock).
- thread x does an UPDATE (or some other modification)
- thread y (the other thread) tries to do an UPDATE (or some other modification), but :bomb: kaboom :boom: because x's update has made it impossible for y to upgrade to a write lock.

This fixes it by always using an explicit BEGIN IMMEDIATE when we open transactions, which avoids the race by forcing unique locking whenever we hold a transaction via `db.tx()`.


Also fixes a bug in the DB cleanup code that was failing in the query to apply scheduled permission changes.