### PR TITLE
New endpoints: info, polling, fetching, permissions, pinning

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -66,7 +66,7 @@ paths:
             Forbidden. Returned if the user is banned from the room or otherwise does not have read
             access to the room.
           content: {}
-  /room/{roomToken}/pollInfo:
+  /room/{roomToken}/pollInfo/{info_updated}:
     get:
       tags: [Rooms]
       summary: Polls a room for metadata updates.
@@ -74,28 +74,32 @@ paths:
         - $ref: "#/components/parameters/pathRoomToken"
         - name: info_updated
           description: >
-            The client's current `info_updates` value for the room.  The full room metadata is
-            returned in the response if the room's last update count does not equal the given value.
-          in: query
+            The client's currently cached `info_updates` value for the room.  The full room metadata
+            is returned in the response if and only if the room's last update count does not equal
+            the given value.
+          in: path
           required: true
           schema:
             type: integer
             format: int64
           example: 4567
       description: >
-        Retrives room metadata for this room, including the instantaneous room details (such as the
-        user's permission and current number of active users)
+        Polls room metadata for this room, always including the instantaneous room details (such as
+        the user's permission and current number of active users), and including the full room
+        metadata if the room's info_updated counter has changed from the provided value.
         
       responses:
         200:
           description: >
             Results of polling the room for updated information.  This endpoint always returns
             ephemeral data, such as the number of active users and the current user's permissions,
-            and will include the full room details if changed since the client's last update.
+            and will include the full room details if and only if it has changed (i.e. info_updates
+            does not match) from the `info_updated` value provided by the requestor.
             
             
-            Note that the `details` field is only present and populated if it differs from the
-            provided `info_updated` value; otherwise the values are unchanged and so it is omitted.
+            Note that the `details` field is only present and populated if the room's `info_updates`
+            counter differs from the provided `info_updated` value; otherwise the values are
+            unchanged and so it is omitted.
           content:
             application/json:
               schema:
@@ -111,8 +115,14 @@ paths:
                     $ref: "#/components/schemas/Room/properties/write"
                   upload:
                     $ref: "#/components/schemas/Room/properties/upload"
-                  info_updates:
-                    $ref: "#/components/schemas/Room/properties/info_updates"
+                  moderator:
+                    $ref: "#/components/schemas/Room/properties/moderator"
+                  admin:
+                    $ref: "#/components/schemas/Room/properties/admin"
+                  global_moderator:
+                    $ref: "#/components/schemas/Room/properties/global_moderator"
+                  global_admin:
+                    $ref: "#/components/schemas/Room/properties/global_admin"
                   details:
                     allOf:
                       - $ref: "#/components/schemas/Room"
@@ -209,6 +219,7 @@ paths:
       summary: Returns a single posted message by ID.
       parameters:
         - $ref: "#/components/parameters/pathRoomToken"
+        - $ref: "#/components/parameters/pathMessageId"
         - name: messageId
           in: path
           description: ID of the message to retrieve.
@@ -338,26 +349,27 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Message'
-  /room/{roomToken}/messages/since/{updateId}:
+  /room/{roomToken}/messages/since/{messageSequence}:
     get:
       tags: [Messages]
       summary: "Retrieves message updates from a room."
       description: >
         This endpoint retrieves new, edited, and deleted messages posted to this room since the
-        given update id.  Returns `limit` messages at a time (100 if no limit is given).  Returned
-        messages include any new messages, updates to existing messages (i.e. edits), and message
-        deletions made to the room since the given update id.  Messages are returned in "update"
-        order, that is, in the order in which the change was applied to the room, from oldest the
-        newest.
+        given message sequence counter.  Returns `limit` messages at a time (100 if no limit is
+        given).  Returned messages include any new messages, updates to existing messages (i.e.
+        edits), and message deletions made to the room since the given update id.  Messages are
+        returned in "update" order, that is, in the order in which the change was applied to the
+        room, from oldest the newest.
       parameters:
         - $ref: "#/components/parameters/pathRoomToken"
         - $ref: "#/components/parameters/queryMessagesLimit"
-        - name: updateId
+        - name: messageSequence
           in: path
           required: true
           description: >
-            The update id from which to retrieve message updates.  To retrieve from the beginning of
-            the room's message history use a value of 0 (the first room update will always be >= 1).
+            The message.seqno value from which to retrieve message updates.  To retrieve from the
+            beginning of the room's message history use a value of 0 (the first room post will
+            always be >= 1).  When polling for updates use the last message.seqno value retrieved.
           schema:
             type: integer
             format: int64
@@ -380,6 +392,91 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Message'
+
+  /room/{roomToken}/pin/{messageId}:
+    post:
+      tags: [Rooms]
+      summary: "Pin a message in this room"
+      description: >
+        Adds a pinned message to this room.  Any existing pinned messages are not removed.  (If you
+        want to remove existing pins then build a sequence request that first calls .../unpin/all).
+        
+        
+        The user must have admin (not just moderator) permissions in the room.
+        
+        
+        Pinned messages that are already pinned will be re-pinned (that is, their pin timestamp and
+        pinning admin user will be updated).  Because pinned messages are returned in pinning-order
+        this allows admins to order multiple pinned messages in a room by re-pinning (via this
+        endpoint) in the order in which pinned messages should be displayed.
+      parameters:
+        - $ref: "#/components/parameters/pathRoomToken"
+        - $ref: "#/components/parameters/pathMessageId"
+      requestBody:
+        description: json dict.  Currently unused and should be an empty dict.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+        403:
+          description: permission denied: the calling user does not have room admin permission
+        404:
+          description: >
+            The given post was not found in this room or is ineligible for pinning (e.g. a whisper,
+            deleted post, or filtered message).
+
+
+  /room/{roomToken}/unpin/{messageId}:
+    post:
+      tags: [Rooms]
+      summary: "Remove a pinned message from this room"
+      description: >
+        Removes a pinned message from this room, if pinned.
+        
+        
+        The user must have admin (not just moderator) permissions in the room.
+      parameters:
+        - $ref: "#/components/parameters/pathRoomToken"
+        - $ref: "#/components/parameters/pathMessageId"
+      responses:
+        200:
+          description: successful operation (or the message was not pinned in the first place).
+          content:
+            application/json:
+              schema:
+                type: object
+        403:
+          description: permission denied: the calling user does not have room admin permission
+
+  /room/{roomToken}/unpin/all:
+    post:
+      tags: [Rooms]
+      summary: "Removes all pinned messages from this room"
+      description: >
+        Removes all pinned messages from this room.
+        
+        
+        The user must have admin (not just moderator) permissions in the room.
+      parameters:
+        - $ref: "#/components/parameters/pathRoomToken"
+      responses:
+        200:
+          description: successful operation: the room now has no pinned messages.
+          content:
+            application/json:
+              schema:
+                type: object
+        403:
+          description: permission denied: the calling user does not have room admin permission
+
   /room/{roomToken}/file:
     post:
       tags: [Files]
@@ -451,8 +548,9 @@ paths:
       description: >
         This is less efficient when a binary upload is possible because the body must be passed as
         base64-encoded data (which is 33% larger).  The user must have upload and posting
-        permissions for the room.  The file will have a default lifetime of 1 hour, but that is
-        extended to 15 days when the containing message referencing the upload is submitted.
+        permissions for the room.  [NOT YET IMPLEMENTED: The file will have a default lifetime of 1
+          hour, but that is extended to 15 days when the containing message referencing the upload
+          is submitted.]
       parameters:
       - $ref: "#/components/parameters/pathRoomToken"
       requestBody:
@@ -565,7 +663,8 @@ paths:
             Expires:
               description: >
                 The HTTP timestamp at which the file is scheduled to expire.  This header is omitted
-                if the attachment is non-expiring (e.g. for attachments in a pinned message).
+                if the attachment is non-expiring (e.g. for attachments in a pinned message [NOT YET
+                IMPLEMENTED]).
               schema:
                 type: string
                 example: "Fri, 22 Oct 2021 00:42:42 GMT"
@@ -577,9 +676,8 @@ paths:
         403:
           $ref: "#/paths/~1room~1%7BroomToken%7D~1file~1%7BfileId%7D/get/responses/403"
         404:
-          $ref: "#/paths/~1room~1%7BroomToken%7D~1file~1%7BfileId%7D/get/responses/403"
+          $ref: "#/paths/~1room~1%7BroomToken%7D~1file~1%7BfileId%7D/get/responses/404"
 
-                    
   /user/{sessionId}/ban:
     post:
       tags: [Users]
@@ -834,7 +932,8 @@ paths:
                   description: >
                     If `true` then this user will be granted moderator and admin permissions to the
                     given rooms or server.  Admin permissions are required to appoint new moderators
-                    or administrators.
+                    or administrators and to alter room info such as the image, adding/removing
+                    pinned messages, and changing the name/description of the room.
                     
                     
                     If false then this user will have their admin permission removed, but will
@@ -1156,13 +1255,13 @@ components:
           description: >
             Monotonic room information counter that increases each time the room's metadata changes.
           example: 12345
-        updates:
+        message_sequence:
           type: integer
           format: int64
           description: >
             Monotonic room post counter that increases each time a message is posted, edited, or
-            deleted in this room.  (Note that changes to this field do *not* update the room's
-            `info_updates` value.)
+            deleted in this room.  (Note that changes to this field do *not* imply an update the
+            room's `info_updates` value, nor vice versa)
           example: 567890
         created:
           type: number
@@ -1170,7 +1269,8 @@ components:
           description: Unix timestamp when the room was created
           example: 1633629915.34607
         active_users:
-          type: object
+          type: integer
+          format: int64
           description: >
             Number of recently active users in the room over recent time periods.
             
@@ -1180,24 +1280,13 @@ components:
             
             
             Note that changes to this field do *not* update the room's `info_updates` value.
-          properties:
-            hour:
-              type: integer
-              format: int64
-              description: "Number of active users in the past hour."
-            day:
-              type: integer
-              format: int64
-              description: "Number of active users in the past 24 hours."
-            week:
-              type: integer
-              format: int64
-              description: "Number of active users in the past week."
-            month:
-              type: integer
-              format: int64
-              description: "Number of active users in the past 30 days."
-          example: { hour: 842, day: 1917, week: 3481, month: 5609 }
+          example: 4567
+        active_users_cutoff:
+          type: integer
+          format: int64
+          description: >
+            The length of time (in seconds) of the active users cutoff.  Defaults to a week
+            (604800), but the open group admin can set it to some other threshold.
         image_id:
           type: integer
           format: int64
@@ -1207,17 +1296,34 @@ components:
         pinned_messages:
           type: array
           items:
-            type: integer
-            format: int64
+          type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+              description: The numeric message id.
+            pinned_at:
+              type: number
+              format: double
+              description: >
+                Unix timestamp of when the message was pinned.
+            pinned_by:
+              allOf:
+                - $ref: "#/components/schemas/SessionID"
+                - type: object
+                  description: >
+                    The session ID of the moderator who pinned this message.
           description: >
-            IDs of this room's pinned messages, in order of when they were pinned.
-          example: [512, 4998, 11]
+            This room's pinned messages, in order of when they were pinned.  Omitted entirely if
+            there are no pinned messages.
+          example: [{"id": 512, "pinned_at", 1642701309.5007384, "pinned_by": "050123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}]
         moderators:
           type: array
           items:
             type: string
           description: >
-            Session IDs of the room's public moderators.
+            Session IDs of the room's publicly viewable moderators.  This does not include room
+            administrators or hidden moderators.
           example:
             - "050123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             - "05fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
@@ -1226,17 +1332,18 @@ components:
           items:
             type: string
           description: >
-            Session IDs of the room's public administrators.  (Administrators are moderators who
-            also have permission to add or remove other moderators.)
+            Session IDs of the room's publicly viewable administrators.  (Administrators are
+            moderators who also have permission to add or remove other moderators.)
           example:
             - "050123456776543210012345677654321001234567765432100123456776543210"
-        hidden_mods:
+        hidden_moderators:
           type: array
           items:
             type: string
           description: >
             Session IDs of moderators who are not publicly displayed as moderators of the room.
-            This field is only present if the requestor is a moderator/admin of the room or server.
+            This field is omitted if the requestor is not a moderator/admin of the room or server,
+            or if the list is empty.
           example:
             - "0589abcdeffedcba9889abcdeffedcba9889abcdeffedcba9889abcdeffedcba98"
         hidden_admins:
@@ -1245,7 +1352,8 @@ components:
             type: string
           description: >
             Session IDs of admins who are not publicly displayed as administrators of the room.
-            This field is only present if the requestor is a moderator/admin of the room or server.
+            This field is omitted if the requestor is not a moderator/admin of the room or server,
+            or if the list is empty.
           example:
             - "050011223344556677001122334455667700112233445566770011223344556677"
         moderator:
@@ -1260,23 +1368,35 @@ components:
             Will be set to true if the requestor is recognized with admin permissions in the room.
             Omitted otherwise.
           example: true
+        global_moderator:
+          type: boolean
+          description: >
+            Will be set to true if the requestor is recognized with global moderator permissions in
+            all rooms.  Omitted otherwise.
+          example: true
+        global_admin:
+          type: boolean
+          description: >
+            Will be set to true if the requestor is recognized with global admin permissions in all
+            rooms.  Omitted otherwise.
+          example: true
         read:
           type: boolean
           description: >
-            Whether the user has permission to read messages in the room.  (Note that changes to
-            this property do not cause an `info_update` increment.)
+            Whether the requesting user has permission to read messages in the room.  (Note that
+            changes to this property do not cause an `info_update` increment.)
           example: true
         write:
           type: boolean
           description: >
-            Whether the user has permission to post messages to the room.  (Note that changes to
-            this property do not cause an `info_update` increment.)
+            Whether the requesting user has permission to post messages to the room.  (Note that
+            changes to this property do not cause an `info_update` increment.)
           example: true
         upload:
           type: boolean
           description: >
-            Whether the user has permissions to upload attachments to messages posted to the room.
-            (Note that changes to this property do not cause an `info_update` increment.)
+            Whether the requesting user has permissions to upload attachments to messages posted to
+            the room.  (Note that changes to this property do not cause an `info_update` increment.)
           example: true
     Message:
       title: The content of a posted message
@@ -1305,13 +1425,19 @@ components:
           description: >
             Unix timestamp of the last edit to this message.  This field is omitted if the message
             has never been edited.
-        updated:
+        seqno:
           type: integer
           format: int64
           description: >
-            Set to the room's current monotonic update counter (*not* a timestamp!) when this
-            message is first posted and whenever the message is edited or deleted.  Thus an update
-            to this value for the same message indicates an update or deletion has occurred.
+            This message's event sequence number in the room; this number is set to the room's
+            current monotonic sequence counter (*not* a timestamp!) when this message is first
+            posted and whenever the message is edited or deleted.  Thus an update to this value for
+            the same message indicates an update or deletion has occurred.
+            
+            
+            Note that this sequence number is used for event tracking, *not* message ordering.  For
+            example, an edit will increase this value so that polling clients will receive the edit,
+            but the edit itself should not re-position the message.
         whisper:
           type: boolean
           description: >
@@ -1350,6 +1476,14 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/RoomToken"
+    pathMessageId:
+      name: messageId
+      in: path
+      description: "Numeric message id of a post."
+      required: true
+      schema:
+        type: integer
+        format: int64
     queryMessagesLimit:
       name: limit
       in: query
@@ -1359,7 +1493,7 @@ components:
         type: integer
         format: int32
         minimum: 1
-        maximum: 255
+        maximum: 256
     pathFileId:
       name: fileId
       in: path

--- a/sogs/db.py
+++ b/sogs/db.py
@@ -118,6 +118,7 @@ def database_init():
         update_message_views,
         create_message_details_deleter,
         check_for_hacks,
+        seqno_etc_updates,
     ):
         if migrate(conn):
             changes = True
@@ -168,6 +169,7 @@ def add_new_columns(conn):
     for table, cols in new_table_cols.items():
         for name, definition in cols.items():
             if name not in metadata.tables[table].c:
+                logging.warning(f"DB migration: Adding new column {table}.{name}")
                 conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
                 added = True
 
@@ -177,6 +179,7 @@ def add_new_columns(conn):
 def add_new_tables(conn):
     added = False
     if 'user_request_nonces' not in metadata.tables:
+        logging.warning("DB migration: Adding new table user_request_nonces")
         if engine.name == 'sqlite':
             conn.execute(
                 """
@@ -212,6 +215,7 @@ CREATE TABLE user_request_nonces (
 def update_message_views(conn):
     if engine.name != "sqlite":
         if any(x not in metadata.tables['message_metadata'].c for x in ('whisper_to', 'filtered')):
+            logging.warning("DB migration: replacing message_metadata/message_details views")
             conn.execute("DROP VIEW IF EXISTS message_metadata")
             conn.execute("DROP VIEW IF EXISTS message_details")
             conn.execute(
@@ -233,6 +237,7 @@ SELECT id, room, "user", session_id, posted, edited, updated, filtered, whisper_
             )
 
             return True
+        # else: don't worry about this for postgresql because initial pg support had the fix
 
     return False
 
@@ -271,8 +276,10 @@ def check_for_hacks(conn):
         # drop it.
         n_fid_hacks = conn.execute("SELECT COUNT(*) FROM file_id_hacks").first()[0]
         if n_fid_hacks == 0:
+            logging.warning("Dropping file_id_hacks old sogs import table (no longer required)")
             metadata.tables['file_id_hacks'].drop(engine)
         else:
+            logging.warning("Keeping file_id_hacks old sogs import table (still required)")
             global HAVE_FILE_ID_HACKS
             HAVE_FILE_ID_HACKS = True
 
@@ -284,6 +291,187 @@ def check_for_hacks(conn):
             ROOM_IMPORT_HACKS[room] = (id_max, offset)
     except Exception:
         pass
+
+
+def seqno_etc_updates(conn):
+    """
+    Rename rooms.updates/messages.updated to rooms.message_sequence/messages.seqno for better
+    disambiguation with rooms.info_updates.
+
+    This also does various other changes/fixes that came at the same time as the column rename:
+
+    - remove "updated" from and add "pinned_by"/"pinned_at" to pinned_messages
+    - recreate the pinned_messages table and triggers because we need several changes:
+        - add trigger to unpin a message when the message is deleted
+        - remove "updates" (now message_sequence) updates from room metadata update trigger
+        - add AFTER UPDATE trigger to properly update room metadata counter when re-pinning an
+          existing pinned message
+    - fix user_permissions view to return true for read/write/upload to true for moderators
+    """
+
+    if 'seqno' in metadata.tables['messages'].c:
+        return False
+
+    with transaction(dbconn=conn):
+        logging.warning("Applying message_sequence renames")
+        conn.execute("ALTER TABLE rooms RENAME COLUMN updates TO message_sequence")
+        conn.execute("ALTER TABLE messages RENAME COLUMN updated TO seqno")
+
+        # We can't insert the required pinned_messages because we don't have the pinned_by user, but
+        # that isn't a big deal since we didn't have any endpoints for pinned messsages before this
+        # anyway, so we just recreate the whole thing (along with triggers which we also need to
+        # update/fix)
+        logging.warning("Recreating pinned_messages table")
+        conn.execute("DROP TABLE pinned_messages")
+        if engine.name == 'sqlite':
+            conn.execute(
+                """
+CREATE TABLE pinned_messages (
+    room INTEGER NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+    message INTEGER NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+    pinned_by INTEGER NOT NULL REFERENCES users(id),
+    pinned_at FLOAT NOT NULL DEFAULT ((julianday('now') - 2440587.5)*86400.0), /* unix epoch when pinned */
+    PRIMARY KEY(room, message)
+)
+"""  # noqa: E501
+            )
+            conn.execute(
+                """
+CREATE TRIGGER messages_after_delete AFTER UPDATE OF data ON messages
+FOR EACH ROW WHEN NEW.data IS NULL AND OLD.data IS NOT NULL
+BEGIN
+    -- Unpin if we deleted a pinned message:
+    DELETE FROM pinned_messages WHERE message = OLD.id;
+END
+"""
+            )
+            conn.execute(
+                """
+CREATE TRIGGER room_metadata_pinned_add AFTER INSERT ON pinned_messages
+FOR EACH ROW
+BEGIN
+    UPDATE rooms SET info_updates = info_updates + 1 WHERE id = NEW.room;
+END
+"""
+            )
+            conn.execute(
+                """
+CREATE TRIGGER room_metadata_pinned_update AFTER UPDATE ON pinned_messages
+FOR EACH ROW
+BEGIN
+    UPDATE rooms SET info_updates = info_updates + 1 WHERE id = NEW.room;
+END
+"""
+            )
+            conn.execute(
+                """
+CREATE TRIGGER room_metadata_pinned_remove AFTER DELETE ON pinned_messages
+FOR EACH ROW
+BEGIN
+    UPDATE rooms SET info_updates = info_updates + 1 WHERE id = OLD.room;
+END
+"""
+            )
+
+            logging.warning("Fixing user_permissions view")
+            conn.execute("DROP VIEW IF EXISTS user_permissions")
+            conn.execute(
+                """
+CREATE VIEW user_permissions AS
+SELECT
+    rooms.id AS room,
+    users.id AS user,
+    users.session_id,
+    CASE WHEN users.banned THEN TRUE ELSE COALESCE(user_permission_overrides.banned, FALSE) END AS banned,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.read, rooms.read) END AS read,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.write, rooms.write) END AS write,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.upload, rooms.upload) END AS upload,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.moderator, FALSE) END AS moderator,
+    CASE WHEN users.admin THEN TRUE ELSE COALESCE(user_permission_overrides.admin, FALSE) END AS admin,
+    -- room_moderator will be TRUE if the user is specifically listed as a moderator of the room
+    COALESCE(user_permission_overrides.moderator OR user_permission_overrides.admin, FALSE) AS room_moderator,
+    -- global_moderator will be TRUE if the user is a global moderator/admin (note that this is
+    -- *not* exclusive of room_moderator: a moderator/admin could be listed in both).
+    COALESCE(users.moderator OR users.admin, FALSE) as global_moderator,
+    -- visible_mod will be TRUE if this mod is a publicly viewable moderator of the room
+    CASE
+        WHEN user_permission_overrides.moderator OR user_permission_overrides.admin THEN user_permission_overrides.visible_mod
+        WHEN users.moderator OR users.admin THEN users.visible_mod
+        ELSE FALSE
+    END AS visible_mod
+FROM
+    users JOIN rooms LEFT OUTER JOIN user_permission_overrides ON
+        users.id = user_permission_overrides.user AND rooms.id = user_permission_overrides.room
+"""  # noqa: E501
+            )
+
+        else:  # postgresql
+            logging.warning("Recreating pinned_messages table")
+            conn.execute(
+                """
+CREATE TABLE pinned_messages (
+    room BIGINT NOT NULL REFERENCES rooms ON DELETE CASCADE,
+    message BIGINT NOT NULL REFERENCES rooms ON DELETE CASCADE,
+    pinned_by BIGINT NOT NULL REFERENCES users,
+    pinned_at FLOAT NOT NULL DEFAULT (extract(epoch from now())),
+    PRIMARY KEY(room, message)
+);
+
+
+-- Trigger to handle required updates after a message gets deleted (in the SOGS context: that is,
+-- has data set to NULL)
+CREATE OR REPLACE FUNCTION trigger_messages_after_delete()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$BEGIN
+    -- Unpin if we deleted a pinned message:
+    DELETE FROM pinned_messages WHERE message = OLD.id;
+    RETURN NULL;
+END;$$;
+CREATE TRIGGER messages_insert_history AFTER UPDATE OF data ON messages
+FOR EACH ROW WHEN (NEW.data IS DISTINCT FROM OLD.data)
+EXECUTE PROCEDURE trigger_messages_insert_history();
+
+CREATE TRIGGER room_metadata_pinned_add AFTER INSERT OR UPDATE ON pinned_messages
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_room_metadata_info_update_new();
+
+CREATE TRIGGER room_metadata_pinned_remove AFTER DELETE ON pinned_messages
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_room_metadata_info_update_old();
+"""
+            )
+
+            logging.warning("Fixing user_permissions view")
+            conn.execute(
+                """
+CREATE OR REPLACE VIEW user_permissions AS
+SELECT
+    rooms.id AS room,
+    users.id AS "user",
+    users.session_id,
+    CASE WHEN users.banned THEN TRUE ELSE COALESCE(user_permission_overrides.banned, FALSE) END AS banned,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.read, rooms.read) END AS read,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.write, rooms.write) END AS write,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.upload, rooms.upload) END AS upload,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.moderator, FALSE) END AS moderator,
+    CASE WHEN users.admin THEN TRUE ELSE COALESCE(user_permission_overrides.admin, FALSE) END AS admin,
+    -- room_moderator will be TRUE if the user is specifically listed as a moderator of the room
+    COALESCE(user_permission_overrides.moderator OR user_permission_overrides.admin, FALSE) AS room_moderator,
+    -- global_moderator will be TRUE if the user is a global moderator/admin (note that this is
+    -- *not* exclusive of room_moderator: a moderator/admin could be listed in both).
+    COALESCE(users.moderator OR users.admin, FALSE) as global_moderator,
+    -- visible_mod will be TRUE if this mod is a publicly viewable moderator of the room
+    CASE
+        WHEN user_permission_overrides.moderator OR user_permission_overrides.admin THEN user_permission_overrides.visible_mod
+        WHEN users.moderator OR users.admin THEN users.visible_mod
+        ELSE FALSE
+    END AS visible_mod
+FROM
+    users CROSS JOIN rooms LEFT OUTER JOIN user_permission_overrides ON
+        (users.id = user_permission_overrides."user" AND rooms.id = user_permission_overrides.room);
+"""  # noqa: E501
+            )
+
+    return True
 
 
 def create_admin_user(dbconn):
@@ -305,7 +493,7 @@ def create_admin_user(dbconn):
 
 
 if config.DB_URL.startswith('postgresql'):
-    # room.token is a 'citext' (case-insensitive text), which sqlalchemy doesn't recognize out of
+    # rooms.token is a 'citext' (case-insensitive text), which sqlalchemy doesn't recognize out of
     # the box.  Map it to a plain TEXT which is good enough for what we need (if we actually needed
     # to generate this wouldn't suffice: we'd have to use something like the sqlalchemy-citext
     # module).
@@ -341,6 +529,12 @@ def _init_engine(*args, **kwargs):
 
     if engine.name == "sqlite":
         import sqlite3
+
+        if sqlite3.sqlite_version_info < (3, 25, 0):
+            raise RuntimeError(
+                f"SQLite3 library version {'.'.join(sqlite3.sqlite_version_info)} "
+                "is too old for pysogs (3.25.0+ required)!"
+            )
 
         have_returning = sqlite3.sqlite_version_info >= (3, 35, 0)
 

--- a/sogs/model/exc.py
+++ b/sogs/model/exc.py
@@ -34,6 +34,14 @@ class NoSuchUser(NotFound):
         super().__init__(f"No such user: {session_id}")
 
 
+class NoSuchPost(NotFound):
+    """Thrown when attempting to retrieve or reference a post that doesn't exist"""
+
+    def __init__(self, id):
+        self.id = id
+        super().__init__(f"No such post: {id}")
+
+
 class AlreadyExists(RuntimeError):
     """
     Thrown when attempting to create a record (e.g. a Room) that already exists.

--- a/sogs/omq.py
+++ b/sogs/omq.py
@@ -9,6 +9,7 @@ from .postfork import postfork
 
 omq = None
 mule_conn = None
+test_suite = False
 
 
 def make_omq():
@@ -60,4 +61,7 @@ def send_mule(command, *args, prefix="worker."):
     if prefix:
         command = prefix + command
 
-    omq.send(mule_conn, command, *(bt_serialize(data) for data in args))
+    if test_suite and omq is None:
+        pass  # TODO: for mule call testing we may want to do something else here?
+    else:
+        omq.send(mule_conn, command, *(bt_serialize(data) for data in args))

--- a/sogs/routes/__init__.py
+++ b/sogs/routes/__init__.py
@@ -3,13 +3,22 @@ from ..web import app
 from .. import config, crypto, http, utils
 from ..model.room import get_readable_rooms
 
-from . import auth, converters, general, legacy, onion_request  # noqa: F401
+from . import auth, converters  # noqa: F401
+
+from .legacy import legacy as legacy_endpoints
+from .general import general as general_endpoints
+from .onion_request import onion_request as onion_request_endpoints
 
 from io import BytesIO
 
 import qrencode
 
 from PIL.Image import NEAREST
+
+
+app.register_blueprint(legacy_endpoints)
+app.register_blueprint(general_endpoints)
+app.register_blueprint(onion_request_endpoints)
 
 
 @app.get("/")

--- a/sogs/routes/__init__.py
+++ b/sogs/routes/__init__.py
@@ -1,4 +1,4 @@
-from flask import abort, request, render_template, Response
+from flask import abort, render_template, Response
 from ..web import app
 from .. import config, crypto, http, utils
 from ..model.room import get_readable_rooms
@@ -8,6 +8,7 @@ from . import auth, converters  # noqa: F401
 from .legacy import legacy as legacy_endpoints
 from .general import general as general_endpoints
 from .onion_request import onion_request as onion_request_endpoints
+from .rooms import rooms as rooms_endpoints
 
 from io import BytesIO
 
@@ -19,6 +20,7 @@ from PIL.Image import NEAREST
 app.register_blueprint(legacy_endpoints)
 app.register_blueprint(general_endpoints)
 app.register_blueprint(onion_request_endpoints)
+app.register_blueprint(rooms_endpoints)
 
 
 @app.get("/")
@@ -54,26 +56,3 @@ def serve_invite_qr(room):
     img = img[-1].resize((512, 512), NEAREST)
     img.save(data, "PNG")
     return Response(data.getvalue(), mimetype="image/png")
-
-
-@app.post("/room/<Room:room>/message")
-def post_to_room(room):
-    user = utils.get_session_id(request)
-    if not user:
-        # todo: correct handling
-        abort(http.FORBIDDEN)
-
-
-@app.get("/room/<Room:room>/messages/recent")
-def get_recent_room_messages(room):
-    """get list of recent messages"""
-    limit = utils.get_int_param('limit', 100, min=1, max=256)
-
-    # FIXME: this is temporary, for the basic front-end; for proper implementation we should have a
-    # user by this point.
-    user = None
-
-    if not room.check_permission(user, read=True):
-        abort(http.FORBIDDEN)
-
-    return utils.jsonify_with_base64(room.get_messages_for(user, recent=True, limit=limit))

--- a/sogs/routes/general.py
+++ b/sogs/routes/general.py
@@ -4,12 +4,14 @@ from .. import http
 from .. import utils
 from .subrequest import make_subrequest
 
-from flask import request, abort, jsonify
+from flask import request, abort, jsonify, Blueprint
 
 # General purpose routes for things like capability retrieval and batching
 
+general = Blueprint('general', __name__)
 
-@app.get("/capabilities")
+
+@general.get("/capabilities")
 def get_caps():
     """
     Return the list of server features/capabilities.  Optionally takes a required= parameter
@@ -114,7 +116,7 @@ def parse_batch_req(r):
     return method, path, headers, json, body
 
 
-@app.post("/batch")
+@general.post("/batch")
 def batch(_sequential=False):
     """
     Submits multiple requests wrapped up in a single request, runs them all, then returns the result
@@ -162,7 +164,7 @@ def batch(_sequential=False):
     return utils.jsonify_with_base64(response)
 
 
-@app.post("/sequence")
+@general.post("/sequence")
 def sequence():
     """
     This is like batch, except that it guarantees to submit requests sequentially in the order

--- a/sogs/routes/legacy.py
+++ b/sogs/routes/legacy.py
@@ -242,7 +242,7 @@ def handle_one_compact_poll(req):
 
     deletions = get_deletions_deprecated(room, req.get('from_deletion_server_id'))
 
-    mods = room.get_mods(user)
+    mods = sorted(session_id for moderators in room.get_mods(user) for session_id in moderators)
 
     return {
         'status_code': http.OK,
@@ -283,7 +283,7 @@ def handle_legacy_store_file():
 
 @legacy.post("/rooms/<Room:room>/image")
 def handle_legacy_upload_room_image(room):
-    user, room = legacy_check_user_room(write=True, upload=True, moderator=True)
+    user, room = legacy_check_user_room(admin=True)
     file_id = process_legacy_file_upload_for_room(user, room, lifetime=None)
     room.image = file_id
     return jsonify({'status_code': http.OK, 'result': file_id})
@@ -375,7 +375,7 @@ def handle_legacy_banlist():
 def handle_legacy_get_mods():
     user, room = legacy_check_user_room(read=True)
 
-    mods = room.get_mods(user)
+    mods = sorted(session_id for moderators in room.get_mods(user) for session_id in moderators)
     return jsonify({"status_code": http.OK, "moderators": mods})
 
 

--- a/sogs/routes/legacy.py
+++ b/sogs/routes/legacy.py
@@ -1,4 +1,4 @@
-from flask import abort, request, jsonify, g
+from flask import abort, request, jsonify, g, Blueprint
 from werkzeug.exceptions import HTTPException
 from ..web import app
 from .. import crypto, config, db, http, utils
@@ -11,6 +11,8 @@ from ..model.exc import NoSuchRoom
 # Legacy endpoints, to eventually be deleted.  These are invoked automatically if the client invokes
 # an endpoint (via onion request) that doesn't start with a `/` -- we prepend `/legacy/` and submit
 # it as an internal request to land here.
+
+legacy = Blueprint('legacy', __name__, url_prefix='/legacy')
 
 
 def get_pubkey_from_token(token):
@@ -90,7 +92,7 @@ def legacy_check_user_room(
     return (user, room)
 
 
-@app.get("/legacy/rooms")
+@legacy.get("/rooms")
 def get_rooms():
     """serve public room list for user"""
 
@@ -103,7 +105,7 @@ def get_rooms():
     )
 
 
-@app.get("/legacy/rooms/<Room:room>")
+@legacy.get("/rooms/<Room:room>")
 def get_room_info(room):
     """serve room metadata"""
     # This really should be authenticated but legacy Session just doesn't pass along auth info.
@@ -112,7 +114,7 @@ def get_room_info(room):
     return jsonify({'room': room_info, 'status_code': http.OK})
 
 
-@app.get("/legacy/rooms/<Room:room>/image")
+@legacy.get("/rooms/<Room:room>/image")
 def legacy_serve_room_image(room):
     """serve room icon"""
     # This really should be authenticated but legacy Session just doesn't pass along auth info.
@@ -124,20 +126,20 @@ def legacy_serve_room_image(room):
     return jsonify({"status_code": http.OK, "result": room.image.read_base64()})
 
 
-@app.get("/legacy/member_count")
+@legacy.get("/member_count")
 def legacy_member_count():
     user, room = legacy_check_user_room(read=True)
 
     return jsonify({"status_code": http.OK, "member_count": room.active_users()})
 
 
-@app.post("/legacy/claim_auth_token")
+@legacy.post("/claim_auth_token")
 def legacy_claim_auth():
     """this does nothing but needs to exist for backwards compat"""
     return jsonify({'status_code': http.OK})
 
 
-@app.get("/legacy/auth_token_challenge")
+@legacy.get("/auth_token_challenge")
 def legacy_auth_token_challenge():
     """
     legacy endpoint to give back an encrypted auth token bundle for the client to use to
@@ -170,7 +172,7 @@ def legacy_transform_message(m):
     }
 
 
-@app.post("/legacy/messages")
+@legacy.post("/messages")
 def handle_post_legacy_message():
 
     user, room = legacy_check_user_room(write=True)
@@ -187,7 +189,7 @@ def handle_post_legacy_message():
     )
 
 
-@app.get("/legacy/messages")
+@legacy.get("/messages")
 def handle_legacy_get_messages():
     from_id = request.args.get('from_server_id')
     limit = utils.get_int_param('limit', 256, min=1, max=256, truncate=True)
@@ -205,7 +207,7 @@ def handle_legacy_get_messages():
     )
 
 
-@app.post("/legacy/compact_poll")
+@legacy.post("/compact_poll")
 def handle_comapct_poll():
     req_list = request.json
     result = list()
@@ -272,14 +274,14 @@ def process_legacy_file_upload_for_room(
     return room.upload_file(file_content, user, filename=filename, lifetime=lifetime)
 
 
-@app.post("/legacy/files")
+@legacy.post("/files")
 def handle_legacy_store_file():
     user, room = legacy_check_user_room(write=True, upload=True)
     file_id = process_legacy_file_upload_for_room(user, room)
     return jsonify({'status_code': http.OK, 'result': file_id})
 
 
-@app.post("/legacy/rooms/<Room:room>/image")
+@legacy.post("/rooms/<Room:room>/image")
 def handle_legacy_upload_room_image(room):
     user, room = legacy_check_user_room(write=True, upload=True, moderator=True)
     file_id = process_legacy_file_upload_for_room(user, room, lifetime=None)
@@ -287,7 +289,7 @@ def handle_legacy_upload_room_image(room):
     return jsonify({'status_code': http.OK, 'result': file_id})
 
 
-@app.get("/legacy/files/<int:file_id>")
+@legacy.get("/files/<int:file_id>")
 def handle_legacy_get_file(file_id):
     user, room = legacy_check_user_room(read=True)
 
@@ -300,7 +302,7 @@ def handle_legacy_get_file(file_id):
     return jsonify_with_base64({'status_code': http.OK, 'result': file_content})
 
 
-@app.post("/legacy/delete_messages")
+@legacy.post("/delete_messages")
 def handle_legacy_delete_messages(ids=None):
     user, room = legacy_check_user_room(read=True)
 
@@ -315,12 +317,12 @@ def handle_legacy_delete_messages(ids=None):
     return jsonify({'status_code': http.OK})
 
 
-@app.delete("/legacy/messages/<int:msgid>")
+@legacy.delete("/messages/<int:msgid>")
 def handle_legacy_single_delete(msgid):
     return handle_legacy_delete_messages(ids=[msgid])
 
 
-@app.post("/legacy/block_list")
+@legacy.post("/block_list")
 def handle_legacy_ban():
     user, room = legacy_check_user_room(moderator=True)
     ban = User(session_id=request.json['public_key'], autovivify=True)
@@ -330,7 +332,7 @@ def handle_legacy_ban():
     return jsonify({"status_code": http.OK})
 
 
-@app.post("/legacy/ban_and_delete_all")
+@legacy.post("/ban_and_delete_all")
 def handle_legacy_banhammer():
     mod, room = legacy_check_user_room(moderator=True)
     ban = User(session_id=request.json['public_key'], autovivify=True)
@@ -342,7 +344,7 @@ def handle_legacy_banhammer():
     return jsonify({"status_code": http.OK})
 
 
-@app.delete("/legacy/block_list/<SessionID:session_id>")
+@legacy.delete("/block_list/<SessionID:session_id>")
 def handle_legacy_unban(session_id):
     user, room = legacy_check_user_room(moderator=True)
     to_unban = User(session_id=session_id, autovivify=False)
@@ -352,7 +354,7 @@ def handle_legacy_unban(session_id):
     abort(http.NOT_FOUND)
 
 
-@app.get("/legacy/block_list")
+@legacy.get("/block_list")
 def handle_legacy_banlist():
     # Bypass permission checks here because we want to continue even if we are banned:
     user, room = legacy_check_user_room(no_perms=True)
@@ -369,7 +371,7 @@ def handle_legacy_banlist():
     return jsonify({"status_code": http.OK, "banned_members": bans})
 
 
-@app.get("/legacy/moderators")
+@legacy.get("/moderators")
 def handle_legacy_get_mods():
     user, room = legacy_check_user_room(read=True)
 
@@ -379,7 +381,7 @@ def handle_legacy_get_mods():
 
 # Posting here adds an admin and requires admin access.  Legacy Session doesn't understand the
 # moderator/admin distinction so we don't support moderator adjustment at all here.
-@app.post("/legacy/moderators")
+@legacy.post("/moderators")
 def handle_legacy_add_admin():
     user, room = legacy_check_user_room(admin=True)
 
@@ -396,7 +398,7 @@ def handle_legacy_add_admin():
 # DELETE here removes an admin or moderator and requires admin access.  (Legacy Session doesn't
 # understand the moderator/admin distinction so we don't distinguish between them and just remove
 # both powers, if present).
-@app.delete("/legacy/moderators/<SessionID:session_id>")
+@legacy.delete("/moderators/<SessionID:session_id>")
 def handle_legacy_remove_admin(session_id):
     user, room = legacy_check_user_room(admin=True)
 

--- a/sogs/routes/onion_request.py
+++ b/sogs/routes/onion_request.py
@@ -1,10 +1,12 @@
-from flask import request, abort
+from flask import request, abort, Blueprint
 import json
 
 from ..web import app
 from .. import crypto, http, utils
 
 from .subrequest import make_subrequest
+
+onion_request = Blueprint('onion_request', __name__)
 
 
 def handle_onionreq_plaintext(body):
@@ -82,8 +84,8 @@ def handle_onionreq_plaintext(body):
         return json.dumps({'status_code': http.BAD_REQUEST}).encode()
 
 
-@app.post("/oxen/v3/lsrpc")
-@app.post("/loki/v3/lsrpc")
+@onion_request.post("/oxen/v3/lsrpc")
+@onion_request.post("/loki/v3/lsrpc")
 def handle_onion_request():
     """
     Parse an onion request, handle it as a subrequest, then encrypt the subrequest result and send

--- a/sogs/routes/rooms.py
+++ b/sogs/routes/rooms.py
@@ -1,0 +1,144 @@
+from .. import config, http, utils
+from ..model import room as mroom
+
+from flask import abort, jsonify, g, Blueprint
+
+# General purpose routes for things like capability retrieval and batching
+
+
+rooms = Blueprint('rooms', __name__)
+
+
+@rooms.get("/room/<Room:room>")
+def get_one_room(room):
+    mods, admins, h_mods, h_admins = room.get_mods(g.user)
+
+    rr = {
+        'token': room.token,
+        'name': room.name,
+        'description': room.description,
+        'info_updates': room.info_updates,
+        'message_sequence': room.message_sequence,
+        'created': room.created,
+        'active_users': room.active_users(),
+        'active_users_cutoff': int(config.ROOM_DEFAULT_ACTIVE_THRESHOLD * 86400),
+        'moderators': mods,
+        'admins': admins,
+        'moderator': room.check_moderator(g.user),
+        'admin': room.check_admin(g.user),
+        'read': room.check_read(g.user),
+        'write': room.check_write(g.user),
+        'upload': room.check_upload(g.user),
+    }
+
+    if room.image_id is not None:
+        rr['image_id'] = room.image_id
+
+    pinned = room.pinned_messages
+    if pinned:
+        rr['pinned_messages'] = pinned
+
+    if h_mods:
+        rr['hidden_moderators'] = h_mods
+    if h_admins:
+        rr['hidden_admins'] = h_admins
+
+    if g.user:
+        if g.user.global_moderator:
+            rr['global_moderator'] = True
+        if g.user.global_admin:
+            rr['global_admin'] = True
+
+    return rr
+
+
+@rooms.get("/rooms")
+def get_rooms():
+    return jsonify([get_one_room(r) for r in mroom.get_readable_rooms(g.user)])
+
+
+@rooms.get("/room/<Room:room>/pollInfo/<int:info_updated>")
+def poll_room_info(room, info_updated):
+    if g.user:
+        g.user.update_room_activity(room)
+
+    result = {
+        'token': room.token,
+        'active_users': room.active_users(),
+        'moderator': room.check_moderator(g.user),
+        'admin': room.check_admin(g.user),
+        'read': room.check_read(g.user),
+        'write': room.check_write(g.user),
+        'upload': room.check_upload(g.user),
+    }
+
+    if room.info_updates != info_updated:
+        result['details'] = get_one_room(room)
+
+    if g.user:
+        if g.user.global_moderator:
+            result['global_moderator'] = True
+        if g.user.global_admin:
+            result['global_admin'] = True
+
+    return jsonify(result)
+
+
+@rooms.get("/room/<Room:room>/messages/since/<int:seqno>")
+def messages_since(room, seqno):
+    if g.user:
+        g.user.update_room_activity(room)
+
+    limit = utils.get_int_param('limit', 100, min=1, max=256, truncate=True)
+
+    return utils.jsonify_with_base64(room.get_messages_for(g.user, limit=limit, after=seqno))
+
+
+@rooms.get("/room/<Room:room>/messages/before/<int:msg_id>")
+def messages_before(room, msg_id):
+    if g.user:
+        g.user.update_room_activity(room)
+
+    limit = utils.get_int_param('limit', 100, min=1, max=256, truncate=True)
+
+    return utils.jsonify_with_base64(room.get_messages_for(g.user, limit=limit, before=msg_id))
+
+
+@rooms.get("/room/<Room:room>/messages/recent")
+def messages_recent(room):
+    if g.user:
+        g.user.update_room_activity(room)
+
+    limit = utils.get_int_param('limit', 100, min=1, max=256, truncate=True)
+
+    return utils.jsonify_with_base64(room.get_messages_for(g.user, limit=limit, recent=True))
+
+
+@rooms.get("/room/<Room:room>/message/<int:msg_id>")
+def message_single(room, msg_id):
+    if g.user:
+        g.user.update_room_activity(room)
+
+    msgs = room.get_messages_for(g.user, single=msg_id)
+    if not msgs:
+        abort(http.NOT_FOUND)
+
+    return utils.jsonify_with_base64(msgs[0])
+
+
+@rooms.post("/room/<Room:room>/pin/<int:msg_id>")
+def message_pin(room, msg_id):
+    room.pin(msg_id, g.user)
+    return jsonify({})
+
+
+@rooms.post("/room/<Room:room>/unpin/<int:msg_id>")
+def message_unpin(room, msg_id):
+    room.unpin(msg_id, g.user)
+    return jsonify({})
+
+
+@rooms.post("/room/<Room:room>/unpin/all")
+def message_unpin_all(room):
+    room.unpin_all(g.user)
+    return jsonify({})

--- a/sogs/schema.pgsql
+++ b/sogs/schema.pgsql
@@ -105,9 +105,9 @@ RETURNS TRIGGER LANGUAGE PLPGSQL AS $$BEGIN
     DELETE FROM pinned_messages WHERE message = OLD.id;
     RETURN NULL;
 END;$$;
-CREATE TRIGGER messages_insert_history AFTER UPDATE OF data ON messages
-FOR EACH ROW WHEN (NEW.data IS DISTINCT FROM OLD.data)
-EXECUTE PROCEDURE trigger_messages_insert_history();
+CREATE TRIGGER messages_after_delete AFTER UPDATE OF data ON messages
+FOR EACH ROW WHEN (NEW.data IS NULL AND OLD.data IS NOT NULL)
+EXECUTE PROCEDURE trigger_messages_after_delete();
 
 
 CREATE TABLE files (
@@ -377,10 +377,9 @@ CREATE INDEX user_permissions_future_at ON user_permission_futures(at);
 -- Nonce tracking to prohibit request signature nonce reuse (thus prevent replay attacks)
 CREATE TABLE user_request_nonces (
     "user" BIGINT NOT NULL REFERENCES users ON DELETE CASCADE,
-    nonce BYTEA NOT NULL,
+    nonce BYTEA NOT NULL UNIQUE,
     expiry FLOAT NOT NULL DEFAULT (extract(epoch from now() + '24 hours'))
 );
-CREATE UNIQUE INDEX user_request_nonces_nonce ON user_request_nonces USING HASH (nonce);
 CREATE INDEX user_request_nonces_expiry ON user_request_nonces(expiry);
 
 

--- a/sogs/schema.sqlite
+++ b/sogs/schema.sqlite
@@ -10,11 +10,11 @@ CREATE TABLE rooms (
     description TEXT, /* Publicly visible room description */
     image INTEGER REFERENCES files(id) ON DELETE SET NULL,
     created FLOAT NOT NULL DEFAULT ((julianday('now') - 2440587.5)*86400.0), /* unix epoch */
-    updates INTEGER NOT NULL DEFAULT 0, /* +1 for each new message, edit or deletion */
+    message_sequence INTEGER NOT NULL DEFAULT 0, /* monotonic current top message.seqno value: +1 for each new message, edit or deletion */
     info_updates INTEGER NOT NULL DEFAULT 0, /* +1 for any room metadata update (name/desc/image/pinned/mods) */
     read BOOLEAN NOT NULL DEFAULT TRUE, /* Whether users can read by default */
     write BOOLEAN NOT NULL DEFAULT TRUE, /* Whether users can post by default */
-    upload BOOLEAN NOT NULL DEFAULT TRUE, /* Whether file uploads are allowed */
+    upload BOOLEAN NOT NULL DEFAULT TRUE, /* Whether file uploads are allowed by default */
     CHECK(token NOT GLOB '*[^a-zA-Z0-9_-]*')
 );
 CREATE INDEX rooms_token ON rooms(token);
@@ -33,7 +33,7 @@ CREATE TABLE messages (
     user INTEGER NOT NULL REFERENCES users(id),
     posted FLOAT NOT NULL DEFAULT ((julianday('now') - 2440587.5)*86400.0), /* unix epoch */
     edited FLOAT,
-    updated INTEGER NOT NULL DEFAULT 0, /* set to the room's `updates` counter when posted/edited/deleted */
+    seqno INTEGER NOT NULL DEFAULT 0, /* set to the room's `message_sequence` counter when posted/edited/deleted */
     data BLOB, /* Actual message content, not including trailing padding; set to null to delete a message */
     data_size INTEGER, /* The message size, including trailing padding (needed because the signature is over the padded data) */
     signature BLOB, /* Signature of `data` by `public_key`; set to null when deleting a message */
@@ -42,7 +42,7 @@ CREATE TABLE messages (
     whisper_mods BOOLEAN NOT NULL DEFAULT FALSE /* If true: this is a whisper that all mods should see (may or may not have a `whisper` target) */
 );
 CREATE INDEX messages_room ON messages(room, posted);
-CREATE INDEX messages_updated ON messages(room, updated);
+CREATE INDEX messages_updated ON messages(room, seqno);
 CREATE INDEX messages_id ON messages(room, id);
 
 CREATE TABLE message_history (
@@ -54,27 +54,27 @@ CREATE TABLE message_history (
 CREATE INDEX message_history_message ON message_history(message);
 CREATE INDEX message_history_replaced ON message_history(replaced);
 
--- Trigger to increment a room's `updates` counter and assign it to the messages `updated` field for
--- new messages.
+-- Trigger to increment a room's `message_sequence` counter and assign it to the message's `seqno`
+-- field for new messages.
 CREATE TRIGGER messages_insert_counter AFTER INSERT ON messages
 FOR EACH ROW
 BEGIN
-    UPDATE rooms SET updates = updates + 1 WHERE id = NEW.room;
-    UPDATE messages SET updated = (SELECT updates FROM rooms WHERE id = NEW.room) WHERE id = NEW.id;
+    UPDATE rooms SET message_sequence = message_sequence + 1 WHERE id = NEW.room;
+    UPDATE messages SET seqno = (SELECT message_sequence FROM rooms WHERE id = NEW.room) WHERE id = NEW.id;
 END;
 
 -- Trigger to do various tasks needed when a message is edited/deleted:
 -- * record the old value into message_history
--- * update the room's `updates` counter (so that clients can learn about the update)
--- * update the message's `updated` value to that new counter
+-- * update the room's `message_sequence` counter (so that clients can learn about the update)
+-- * update the message's `sequence` value to that new counter
 -- * update the message's `edit` timestamp
 CREATE TRIGGER messages_insert_history AFTER UPDATE OF data ON messages
 FOR EACH ROW WHEN NEW.data IS NOT OLD.data
 BEGIN
     INSERT INTO message_history (message, data, signature) VALUES (NEW.id, OLD.data, OLD.signature);
-    UPDATE rooms SET updates = updates + 1 WHERE id = NEW.room;
+    UPDATE rooms SET message_sequence = message_sequence + 1 WHERE id = NEW.room;
     UPDATE messages SET
-        updated = (SELECT updates FROM rooms WHERE id = NEW.room),
+        seqno = (SELECT message_sequence FROM rooms WHERE id = NEW.room),
         edited = (julianday('now') - 2440587.5)*86400.0
     WHERE id = NEW.id;
 END;
@@ -82,26 +82,21 @@ END;
 CREATE TABLE pinned_messages (
     room INTEGER NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
     message INTEGER NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
-    updated INTEGER NOT NULL  DEFAULT 0, /* set to the room's `info_updated` counter when pinned (used for ordering). */
+    pinned_by INTEGER NOT NULL REFERENCES users(id),
+    pinned_at FLOAT NOT NULL DEFAULT ((julianday('now') - 2440587.5)*86400.0), /* unix epoch when pinned */
     PRIMARY KEY(room, message)
 );
 
 
--- Trigger to handle moving a message from one room to another; we reset the posted time to now, and
--- reset the updated value to the new room's value so that the moved message is treated as a brand new message in
--- the new room.  We also clear the message as the pinned message from the moved-from room.
--- FIXME TODO: this isn't right because the old room won't have any record of it being moved, and so
--- clients won't know that they should remove it.  Perhaps instead we should implement moving as a
--- delete + reinsert, via a INSTEAD OF trigger.
-/*
-CREATE TRIGGER message_mover AFTER UPDATE OF room ON messages
-FOR EACH ROW WHEN NEW.room != OLD.room
+-- Trigger to handle required updates after a message gets deleted (in the SOGS context: that is,
+-- has data set to NULL)
+CREATE TRIGGER messages_after_delete AFTER UPDATE OF data ON messages
+FOR EACH ROW WHEN NEW.data IS NULL AND OLD.data IS NOT NULL
 BEGIN
-    UPDATE messages SET posted = ((julianday('now') - 2440587.5)*86400.0), updated = FALSE
-        WHERE messages.id = NEW.id;
-    UPDATE rooms SET pinned = NULL WHERE id = OLD.room AND pinned = OLD.id;
+    -- Unpin if we deleted a pinned message:
+    DELETE FROM pinned_messages WHERE message = OLD.id;
 END;
-*/
+
 
 CREATE TABLE files (
     id INTEGER NOT NULL PRIMARY KEY,
@@ -170,7 +165,7 @@ END;
 -- View of `messages` that is useful for manually inspecting table contents by only returning the
 -- length (rather than raw bytes) for data/signature.
 CREATE VIEW message_metadata AS
-SELECT id, room, user, session_id, posted, edited, updated, whisper_to,
+SELECT id, room, user, session_id, posted, edited, seqno, whisper_to,
         length(data) AS data_unpadded, data_size, length(signature) as signature_length
     FROM message_details;
 
@@ -238,7 +233,7 @@ FOR EACH ROW WHEN
     NEW.description IS NOT OLD.description OR
     NEW.image IS NOT OLD.image
 BEGIN
-    UPDATE rooms SET updates = updates + 1, info_updates = info_updates + 1 WHERE id = NEW.id;
+    UPDATE rooms SET info_updates = info_updates + 1 WHERE id = NEW.id;
 END;
 -- Triggers to update `info_updates` when the mod list changes:
 CREATE TRIGGER room_metadata_mods_insert AFTER INSERT ON user_permission_overrides
@@ -279,7 +274,11 @@ CREATE TRIGGER room_metadata_pinned_add AFTER INSERT ON pinned_messages
 FOR EACH ROW
 BEGIN
     UPDATE rooms SET info_updates = info_updates + 1 WHERE id = NEW.room;
-    UPDATE pinned_messages SET updated = (SELECT info_updates FROM rooms WHERE id = NEW.room) WHERE id = NEW.id;
+END;
+CREATE TRIGGER room_metadata_pinned_update AFTER UPDATE ON pinned_messages
+FOR EACH ROW
+BEGIN
+    UPDATE rooms SET info_updates = info_updates + 1 WHERE id = NEW.room;
 END;
 CREATE TRIGGER room_metadata_pinned_remove AFTER DELETE ON pinned_messages
 FOR EACH ROW
@@ -298,9 +297,9 @@ SELECT
     users.id AS user,
     users.session_id,
     CASE WHEN users.banned THEN TRUE ELSE COALESCE(user_permission_overrides.banned, FALSE) END AS banned,
-    COALESCE(user_permission_overrides.read, rooms.read) AS read,
-    COALESCE(user_permission_overrides.write, rooms.write) AS write,
-    COALESCE(user_permission_overrides.upload, rooms.upload) AS upload,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.read, rooms.read) END AS read,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.write, rooms.write) END AS write,
+    CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.upload, rooms.upload) END AS upload,
     CASE WHEN users.moderator THEN TRUE ELSE COALESCE(user_permission_overrides.moderator, FALSE) END AS moderator,
     CASE WHEN users.admin THEN TRUE ELSE COALESCE(user_permission_overrides.admin, FALSE) END AS admin,
     -- room_moderator will be TRUE if the user is specifically listed as a moderator of the room

--- a/sogs/web.py
+++ b/sogs/web.py
@@ -10,14 +10,15 @@ coloredlogs.install(milliseconds=True, isatty=True, logger=app.logger, level=con
 # below, because they depend on this existing.
 if not hasattr(flask.Flask, 'post'):
 
-    def _add_flask_method(name):
+    def _add_route_shortcut(on, name):
         def meth(self, rule: str, **options):
             return self.route(rule, methods=[name.upper()], **options)
 
-        setattr(flask.Flask, name, meth)
+        setattr(on, name, meth)
 
     for method in ('get', 'post', 'put', 'delete', 'patch'):
-        _add_flask_method(method)
+        _add_route_shortcut(flask.Flask, method)
+        _add_route_shortcut(flask.Blueprint, method)
 
 
 def get_db_conn():

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -1,0 +1,77 @@
+from nacl.public import PublicKey, PrivateKey
+from typing import Optional
+import time
+from hashlib import blake2b
+from nacl.bindings import crypto_scalarmult
+from nacl.utils import random
+
+import sogs.utils
+import sogs.crypto
+
+
+def x_sogs_nonce():
+    return random(16)
+
+
+def x_sogs_raw(
+    a: PrivateKey,
+    A: PublicKey,
+    B: PublicKey,
+    method: str,
+    full_path: str,
+    body: Optional[bytes] = None,
+    b64_nonce: bool = True,
+    id_prefix: str = '05',
+    timestamp_off: int = 0,
+):
+    """
+    Calculates X-SOGS-* headers.
+
+    Returns 4 elements: the headers dict, the nonce bytes, timestamp int, and hash bytes.
+
+    Use x_sogs(...) instead if you don't need the nonce/timestamp/hash values.
+    """
+    n = x_sogs_nonce()
+    ts = int(time.time()) + timestamp_off
+
+    a_bytes, A_bytes, B_bytes = (x.encode() for x in (a, A, B))
+
+    h = {
+        'X-SOGS-Pubkey': id_prefix + A_bytes.hex(),
+        'X-SOGS-Nonce': sogs.utils.encode_base64(n) if b64_nonce else n.hex(),
+        'X-SOGS-Timestamp': str(ts),
+    }
+
+    # Deliberately using hashlib (rather than nacl) here to use an independent blake2b
+    # implementation from the sogs code.
+    shared_key = blake2b(
+        crypto_scalarmult(a_bytes, B_bytes) + A_bytes + B_bytes,
+        digest_size=42,
+        salt=n,
+        person=b'sogs.shared_keys',
+    ).digest()
+
+    hasher = blake2b(
+        method.encode() + full_path.encode() + h['X-SOGS-Timestamp'].encode(),
+        digest_size=42,
+        key=shared_key,
+        salt=n,
+        person=b'sogs.auth_header',
+    )
+    if body is not None and len(body):
+        hasher.update(body)
+    hsh = hasher.digest()
+    h['X-SOGS-Hash'] = sogs.utils.encode_base64(hsh)
+
+    return h, n, ts, hsh
+
+
+def x_sogs(*args, **kwargs):
+    return x_sogs_raw(*args, **kwargs)[0]
+
+
+def x_sogs_for(user, *args, **kwargs):
+    a = user.privkey
+    A = a.public_key
+    B = sogs.crypto.server_pubkey
+    return x_sogs(a, A, B, *args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ from sogs import web  # noqa: E402
 from sogs.model.room import Room  # noqa: E402
 from sogs.model.user import SystemUser  # noqa: E402
 
+import sogs.omq  # noqa: E402
+
+
+sogs.omq.test_suite = True
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -127,6 +132,17 @@ def global_mod(db):
     u = user.User()
     u.set_moderator(added_by=SystemUser())
     return u
+
+
+@pytest.fixture
+def no_rate_limit():
+    """Disables post rate limiting for the test"""
+    import sogs.model.room as mroom
+
+    saved = (mroom.rate_limit_size, mroom.rate_limit_interval)
+    mroom.rate_limit_size, mroom.rate_limit_interval = None, None
+    yield None
+    mroom.rate_limit_size, mroom.rate_limit_interval = saved
 
 
 web.app.config.update({'TESTING': True})

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,76 +1,11 @@
 from sogs.web import app
 from sogs.crypto import server_pubkey
 from sogs.routes.auth import user_required
+from auth import x_sogs_raw, x_sogs
 import sogs.utils
 
-from hashlib import blake2b
 import json
-from nacl.bindings import crypto_scalarmult
-from nacl.public import PublicKey, PrivateKey
-from nacl.utils import random
-import time
-from typing import Optional
-
-
-def nonce():
-    return random(16)
-
-
-def x_sogs_raw(
-    a: PrivateKey,
-    A: PublicKey,
-    B: PublicKey,
-    method: str,
-    full_path: str,
-    body: Optional[bytes] = None,
-    b64_nonce: bool = True,
-    id_prefix: str = '05',
-    timestamp_off: int = 0,
-):
-    """
-    Calculates X-SOGS-* headers.
-
-    Returns 4 elements: the headers dict, the nonce bytes, timestamp int, and hash bytes.
-
-    Use x_sogs(...) instead if you don't need the nonce/timestamp/hash values.
-    """
-    n = nonce()
-    ts = int(time.time()) + timestamp_off
-
-    a_bytes, A_bytes, B_bytes = (x.encode() for x in (a, A, B))
-
-    h = {
-        'X-SOGS-Pubkey': id_prefix + A_bytes.hex(),
-        'X-SOGS-Nonce': sogs.utils.encode_base64(n) if b64_nonce else n.hex(),
-        'X-SOGS-Timestamp': str(ts),
-    }
-
-    # Deliberately using hashlib (rather than nacl) here to use an independent blake2b
-    # implementation from the sogs code.
-    shared_key = blake2b(
-        crypto_scalarmult(a_bytes, B_bytes) + A_bytes + B_bytes,
-        digest_size=42,
-        salt=n,
-        person=b'sogs.shared_keys',
-    ).digest()
-
-    hasher = blake2b(
-        method.encode() + full_path.encode() + h['X-SOGS-Timestamp'].encode(),
-        digest_size=42,
-        key=shared_key,
-        salt=n,
-        person=b'sogs.auth_header',
-    )
-    if body is not None and len(body):
-        hasher.update(body)
-    hsh = hasher.digest()
-    h['X-SOGS-Hash'] = sogs.utils.encode_base64(hsh)
-
-    return h, n, ts, hsh
-
-
-def x_sogs(*args, **kwargs):
-    return x_sogs_raw(*args, **kwargs)[0]
+from nacl.public import PrivateKey
 
 
 @app.get("/auth_test/whoami")

--- a/tests/test_room_routes.py
+++ b/tests/test_room_routes.py
@@ -1,0 +1,554 @@
+import pytest
+import time
+from sogs.model.room import Room
+from sogs.model.file import File
+from sogs import utils
+import sogs.config
+from auth import x_sogs_for
+
+
+def test_list(client, room, user, user2, admin, mod, global_mod, global_admin):
+
+    room2 = Room.create('room2', name='Room 2', description='Test suite testing room2')
+    room2.default_write = False
+    room2.default_upload = False
+
+    room3 = Room.create('room3', name='Room 3', description='Test suite testing room3')
+    room3.default_read = False
+    room3.default_write = False
+    room3.default_upload = False
+
+    r2_expected = {
+        "token": "room2",
+        "name": "Room 2",
+        "description": "Test suite testing room2",
+        "info_updates": 0,
+        "message_sequence": 0,
+        "created": room2.created,
+        "active_users": 0,
+        "active_users_cutoff": int(86400 * sogs.config.ROOM_DEFAULT_ACTIVE_THRESHOLD),
+        "moderators": [],
+        "admins": [],
+        "moderator": False,
+        "admin": False,
+        "read": True,
+        "write": False,
+        "upload": False,
+    }
+    r_expected = {
+        "token": "test-room",
+        "name": "Test room",
+        "description": "Test suite testing room",
+        "info_updates": 2,
+        "message_sequence": 0,
+        "created": room.created,
+        "active_users": 0,
+        "active_users_cutoff": int(86400 * sogs.config.ROOM_DEFAULT_ACTIVE_THRESHOLD),
+        "moderators": [mod.session_id],
+        "admins": [admin.session_id],
+        "moderator": False,
+        "admin": False,
+        "read": True,
+        "write": True,
+        "upload": True,
+    }
+    r3_expected = {
+        "token": "room3",
+        "name": "Room 3",
+        "description": "Test suite testing room3",
+        "info_updates": 0,
+        "message_sequence": 0,
+        "created": room3.created,
+        "active_users": 0,
+        "active_users_cutoff": int(86400 * sogs.config.ROOM_DEFAULT_ACTIVE_THRESHOLD),
+        "moderators": [],
+        "admins": [],
+        "moderator": False,
+        "admin": False,
+        "read": True,
+        "write": False,
+        "upload": False,
+    }
+
+    exp_mod = {
+        **{p: True for p in ("moderator", "read", "write", "upload")},
+        "hidden_moderators": [global_mod.session_id],
+        "hidden_admins": [global_admin.session_id],
+    }
+    exp_admin = {**exp_mod, "admin": True}
+    exp_gmod = {**exp_mod, "global_moderator": True}
+    exp_gadmin = {**exp_admin, "global_moderator": True, "global_admin": True}
+
+    room3.set_permissions(user2, mod=global_mod, read=True)
+    room2.set_permissions(user2, mod=global_admin, write=True)
+
+    # Unauthed user: should see just room and room2 but not room3
+    r = client.get("/rooms")
+    assert r.status_code == 200
+    assert r.json == [r2_expected, r_expected]
+
+    r = client.get("/rooms", headers=x_sogs_for(user, "GET", "/rooms"))
+    assert r.status_code == 200
+    assert r.json == [r2_expected, r_expected]
+
+    r = client.get("/rooms", headers=x_sogs_for(user2, "GET", "/rooms"))
+    assert r.status_code == 200
+    assert r.json == [{**r2_expected, "write": True}, r3_expected, r_expected]
+
+    r = client.get("/rooms", headers=x_sogs_for(mod, "GET", "/rooms"))
+    assert r.status_code == 200
+    assert r.json == [r2_expected, {**r_expected, **exp_mod}]
+
+    r = client.get("/rooms", headers=x_sogs_for(admin, "GET", "/rooms"))
+    assert r.status_code == 200
+    assert r.json == [r2_expected, {**r_expected, **exp_admin}]
+
+    r = client.get("/rooms", headers=x_sogs_for(global_mod, "GET", "/rooms"))
+    assert r.status_code == 200
+    assert r.json == [
+        {**r2_expected, **exp_gmod},
+        {**r3_expected, **exp_gmod},
+        {**r_expected, **exp_gmod},
+    ]
+
+    r = client.get("/rooms", headers=x_sogs_for(global_admin, "GET", "/rooms"))
+    assert r.status_code == 200
+    assert r.json == [
+        {**r2_expected, **exp_gadmin},
+        {**r3_expected, **exp_gadmin},
+        {**r_expected, **exp_gadmin},
+    ]
+
+    r = client.get("/room/room3", headers=x_sogs_for(user, "GET", "/room/room3"))
+    assert r.status_code == 200
+    assert r.json == {**r3_expected, "read": False}
+
+    r = client.get("/room/room3", headers=x_sogs_for(user2, "GET", "/room/room3"))
+    assert r.status_code == 200
+    assert r.json == r3_expected
+
+    r = client.get("/room/room3", headers=x_sogs_for(global_admin, "GET", "/room/room3"))
+    assert r.status_code == 200
+    assert r.json == {**r3_expected, **exp_gadmin}
+
+
+def test_polling(client, room, user, user2, mod, admin, global_mod, global_admin):
+    r = client.get("/room/test-room", headers=x_sogs_for(user, "GET", "/room/test-room"))
+    assert r.status_code == 200
+    info_up = r.json['info_updates']
+    assert info_up == 2
+
+    basic = {
+        'token': 'test-room',
+        'active_users': 1,
+        'moderator': False,
+        'admin': False,
+        'read': True,
+        'write': True,
+        'upload': True,
+    }
+    details = {
+        "token": "test-room",
+        "name": "Test room",
+        "description": "Test suite testing room",
+        "info_updates": 2,
+        "message_sequence": 0,
+        "created": room.created,
+        "active_users": 1,
+        "active_users_cutoff": int(86400 * sogs.config.ROOM_DEFAULT_ACTIVE_THRESHOLD),
+        "moderators": [mod.session_id],
+        "admins": [admin.session_id],
+        "moderator": False,
+        "admin": False,
+        "read": True,
+        "write": True,
+        "upload": True,
+    }
+
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    assert r.json == basic
+
+    # Make various changes that should each update the room info updates:
+
+    # Changing name
+    room.name = 'Test Room'
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    details['info_updates'] += 1
+    details['name'] = 'Test Room'
+    assert r.json == {**basic, 'details': details}
+
+    info_up += 1
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(mod, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    basic['active_users'] += 1
+    details['active_users'] += 1
+    assert r.status_code == 200
+    assert r.json == {**basic, 'moderator': True}
+
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(admin, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    basic['active_users'] += 1
+    details['active_users'] += 1
+    assert r.json == {**basic, 'moderator': True, 'admin': True}
+
+    # Changing description
+    room.description = 'Test suite testing room new desc'
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    details['info_updates'] += 1
+    details['description'] = 'Test suite testing room new desc'
+    assert r.json == {**basic, 'details': details}
+    info_up += 1
+    assert info_up == details['info_updates']
+    assert (
+        'details'
+        not in client.get(
+            f"/room/test-room/pollInfo/{info_up}",
+            headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+        ).json
+    )
+
+    # Setting room image
+    img = File(
+        id=room.upload_file(
+            content=b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02'
+            b'\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDAT\x08\xd7c\x90\x8dp\x04\x00\x01L\x00\xb7\xb1'
+            b'o\xa7\\\x00\x00\x00\x00IEND\xaeB`\x82',
+            uploader=mod,
+            filename='tiny.png',
+        )
+    )
+    room.image = img
+
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    details['image_id'] = 1
+    details['info_updates'] += 1
+    assert r.json == {**basic, 'details': details}
+    info_up += 1
+    assert info_up == details['info_updates']
+
+    assert (
+        'details'
+        not in client.get(
+            f"/room/test-room/pollInfo/{info_up}",
+            headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+        ).json
+    )
+
+    # Add moderator
+    room.set_moderator(user, added_by=admin)
+
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    details['info_updates'] += 1
+    details['moderators'] = sorted(details['moderators'] + [user.session_id])
+    assert r.json == {
+        **basic,
+        'moderator': True,
+        'details': {
+            **details,
+            'moderator': True,
+            'hidden_admins': [global_admin.session_id],
+            'hidden_moderators': [global_mod.session_id],
+        },
+    }
+    info_up += 1
+    assert info_up == details['info_updates']
+
+    # Remove moderator
+    room.remove_moderator(user, removed_by=admin)
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    details['info_updates'] += 1
+    details['moderators'] = sorted(x for x in details['moderators'] if x != user.session_id)
+    assert r.json == {**basic, 'details': details}
+    info_up += 1
+    assert info_up == details['info_updates']
+
+    # Add global admin
+    user2.set_moderator(added_by=global_admin, admin=True, visible=True)
+
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    details['info_updates'] += 1
+    details['admins'] = sorted(details['admins'] + [user2.session_id])
+    assert r.json == {**basic, 'details': details}
+    info_up += 1
+    assert info_up == details['info_updates']
+
+    # Remove global admin
+    user2.remove_moderator(removed_by=user2)
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    details['info_updates'] += 1
+    details['admins'] = sorted(x for x in details['admins'] if x != user2.session_id)
+    assert r.json == {**basic, 'details': details}
+    info_up += 1
+    assert info_up == details['info_updates']
+
+    # Post a message should *not* change info_updates, but should change the message_sequence
+    room.add_post(user, b'fake data', b'fake sig')
+
+    r = client.get(
+        f"/room/test-room/pollInfo/{info_up}",
+        headers=x_sogs_for(user, "GET", f"/room/test-room/pollInfo/{info_up}"),
+    )
+    assert r.status_code == 200
+    assert 'details' not in r.json
+
+    details['message_sequence'] += 1
+    r = client.get("/room/test-room", headers=x_sogs_for(user, "GET", "/room/test-room"))
+    assert r.json['message_sequence'] == details['message_sequence']
+
+
+def test_fetch_since(client, room, user, no_rate_limit):
+    top_fetched = 0
+    fetches = 0
+    counter = 0  # seqno should follow this
+    counts = (1, 1, 1, 2, 0, 3, 0, 0, 5, 7, 11, 12, 0, 25, 0, 101, 0, 203, 0, 100, 200)
+    for n in counts:
+        for i in range(counter + 1, counter + 1 + n):
+            room.add_post(user, f"fake data {i}".encode(), f"fake sig {i}".encode())
+        counter += n
+
+        done = False
+        while not done:
+            url = f"/room/test-room/messages/since/{top_fetched}"
+            r = client.get(url, headers=x_sogs_for(user, "GET", url))
+            assert r.status_code == 200
+            fetches += 1
+            c = min(100, counter - top_fetched)
+            assert len(r.json) == c
+            for i in range(c):
+                post = r.json[i]
+                j = top_fetched + 1
+                assert set(post.keys()) == {
+                    'id',
+                    'session_id',
+                    'seqno',
+                    'data',
+                    'signature',
+                    'posted',
+                }
+                assert post['session_id'] == user.session_id
+                assert post['seqno'] == j
+                assert utils.decode_base64(post['data']) == f"fake data {j}".encode()
+                assert utils.decode_base64(post['signature']) == f"fake sig {j}".encode()
+                assert -1 <= post['posted'] - time.time() <= 1
+
+                top_fetched = post['seqno']
+
+            assert top_fetched <= counter
+            done = len(r.json) < 100
+
+    # Every loop above does one fetch unconditionally, and we require one additional fetch each time
+    # we get to 100, 200, etc.
+    assert fetches == sum(1 + c // 100 for c in counts)
+
+    # Start over from the beginning, this time using a limit
+    done, fetches, top_fetched = False, 0, 0
+    while not done:
+        url = f"/room/test-room/messages/since/{top_fetched}?limit=25"
+        r = client.get(url, headers=x_sogs_for(user, "GET", url))
+        assert r.status_code == 200
+        fetches += 1
+        assert [utils.decode_base64(post['data']) for post in r.json] == [
+            f'fake data {i}'.encode()
+            for i in range(top_fetched + 1, top_fetched + 1 + min(25, len(r.json)))
+        ]
+
+        done = len(r.json) < 25
+        top_fetched += len(r.json)
+
+    assert fetches == (sum(counts) + 24) // 25
+
+
+def test_fetch_before(client, room, user, no_rate_limit):
+    for i in range(1000):
+        room.add_post(user, f"data-{i}".encode(), f"fake sig {i}".encode())
+
+    url = "/room/test-room/messages/recent"
+    r100 = client.get(url, headers=x_sogs_for(user, "GET", url))
+    assert len(r100.json) == 100
+
+    assert [p['id'] for p in r100.json] == list(range(1000, 900, -1))
+
+    url = "/room/test-room/messages/recent?limit=201"
+    r201 = client.get(url, headers=x_sogs_for(user, "GET", url))
+    assert len(r201.json) == 201
+
+    assert r100.json == r201.json[:100]
+
+    url = f"/room/test-room/messages/before/{r100.json[-1]['id']}?limit=101"
+    r101 = client.get(url, headers=x_sogs_for(user, "GET", url))
+    assert r101.status_code == 200
+
+    assert r100.json + r101.json == r201.json
+
+    before = r201.json[-1]['id']
+    sizes = (45, None, None, 255, None, 100, 1, 98)
+    next_exp = before - 1
+    for limit in sizes:
+        url = f"/room/test-room/messages/before/{before}"
+        if limit is not None:
+            url = url + f"?limit={limit}"
+        else:
+            limit = 100
+        r = client.get(url, headers=x_sogs_for(user, "GET", url))
+        assert r.status_code == 200
+        assert len(r.json) == limit
+        assert r.json[0]['id'] == next_exp
+        assert r.json[-1]['id'] == next_exp - limit + 1
+        next_exp -= limit
+        before = r.json[-1]['id']
+
+    assert next_exp == 0
+    assert before == 1
+    url = f"/room/test-room/messages/before/{before}"
+    r = client.get(url, headers=x_sogs_for(user, "GET", url))
+    assert len(r.json) == 0
+
+
+def test_fetch_one(client, room, user, no_rate_limit):
+    posts = [room.add_post(user, f"data-{i}".encode(), f"fake sig {i}".encode()) for i in range(10)]
+
+    for i in (5, 2, 8, 7, 9, 6, 10, 1, 3, 4):
+        url = f"/room/test-room/message/{i}"
+        r = client.get(url, headers=x_sogs_for(user, "GET", url))
+        assert r.status_code == 200
+        p = posts[i - 1].copy()
+        for x in ('data', 'signature'):
+            p[x] = utils.encode_base64(p[x])
+        assert r.json == p
+
+
+def test_pinning(client, room, user, admin, no_rate_limit):
+    for i in range(10):
+        room.add_post(user, f"data-{i}".encode(), f"fake sig {i}".encode())
+
+    def room_json():
+        r = client.get("/room/test-room", headers=x_sogs_for(user, "GET", "/room/test-room"))
+        assert r.status_code == 200
+        return r.json
+
+    assert room_json()['info_updates'] == 1
+
+    import werkzeug.exceptions
+
+    url = "/room/test-room/pin/3"
+    with pytest.raises(werkzeug.exceptions.Forbidden):
+        r = client.post(url, data=b'{}', headers=x_sogs_for(user, "POST", url, b'{}'))
+
+    assert room_json()['info_updates'] == 1
+
+    r = client.post(url, data=b'{}', headers=x_sogs_for(admin, "POST", url, b'{}'))
+    assert r.status_code == 200
+
+    ri = room_json()
+    assert ri['info_updates'] == 2
+    assert -1 < ri['pinned_messages'][0]['pinned_at'] - time.time() < 1
+    del ri['pinned_messages'][0]['pinned_at']
+    assert ri['pinned_messages'] == [{'id': 3, 'pinned_by': admin.session_id}]
+
+    url = "/room/test-room/pin/7"
+    r = client.post(url, data=b'{}', headers=x_sogs_for(admin, "POST", url, b'{}'))
+    assert r.status_code == 200
+    time.sleep(0.001)
+    url = "/room/test-room/pin/5"
+    r = client.post(url, data=b'{}', headers=x_sogs_for(admin, "POST", url, b'{}'))
+    assert r.status_code == 200
+
+    ri = room_json()
+    assert ri['info_updates'] == 4
+    rpm = ri['pinned_messages']
+    assert (
+        time.time() - 1
+        < rpm[0]['pinned_at']
+        < rpm[1]['pinned_at']
+        < rpm[2]['pinned_at']
+        < time.time() + 1
+    )
+    for p in ri['pinned_messages']:
+        del p['pinned_at']
+
+    assert ri['pinned_messages'] == [
+        {'id': 3, 'pinned_by': admin.session_id},
+        {'id': 7, 'pinned_by': admin.session_id},
+        {'id': 5, 'pinned_by': admin.session_id},
+    ]
+
+    url = "/room/test-room/pin/7"
+    r = client.post(url, data=b'{}', headers=x_sogs_for(admin, "POST", url, b'{}'))
+    assert r.status_code == 200
+
+    ri = room_json()
+    assert ri['info_updates'] == 5
+    rpm = ri['pinned_messages']
+    assert (
+        time.time() - 1
+        < rpm[0]['pinned_at']
+        < rpm[1]['pinned_at']
+        < rpm[2]['pinned_at']
+        < time.time() + 1
+    )
+    for p in ri['pinned_messages']:
+        del p['pinned_at']
+
+    assert ri['pinned_messages'] == [
+        {'id': 3, 'pinned_by': admin.session_id},
+        {'id': 5, 'pinned_by': admin.session_id},
+        {'id': 7, 'pinned_by': admin.session_id},
+    ]
+
+    url = "/room/test-room/unpin/5"
+    r = client.post(url, data=b'{}', headers=x_sogs_for(admin, "POST", url, b'{}'))
+    assert r.status_code == 200
+
+    ri = room_json()
+    rpm = ri['pinned_messages']
+    assert time.time() - 1 < rpm[0]['pinned_at'] < rpm[1]['pinned_at'] < time.time() + 1
+    for p in ri['pinned_messages']:
+        del p['pinned_at']
+
+    assert ri['pinned_messages'] == [
+        {'id': 3, 'pinned_by': admin.session_id},
+        {'id': 7, 'pinned_by': admin.session_id},
+    ]
+
+    url = "/room/test-room/unpin/all"
+    r = client.post(url, data=b'{}', headers=x_sogs_for(admin, "POST", url, b'{}'))
+    assert r.status_code == 200
+
+    assert 'pinned_messages' not in room_json()


### PR DESCRIPTION
Implements a bunch of new sogs endpoints, mostly as described by the api
spec (with some changes applied to the spec, where needed):

- `/rooms` -- returns list of readable rooms, including various room
  metadata plus derived permission of the user in the rooms

- `/room/<token>` -- same as above, but for a single room

- `/room/<token>/pollInfo/<id>` -- polls a room for any metadata updates
  applied since `<id>`.  If the room's current metadata tracker
  (`info_updates`) is unchanged from `<id>` then this returns a light
  poll response with just active_users and current user permissions in
  the room; otherwise it includes that plus a `details` key containing
  the full room metadata (as would be returned by `/room/<token>`).

Message fetching endpoints:
- `/room/<token>/message/1234` retrieves a single message with the given
  id.
- `/room/<token>/messages/recent` retrieves the most recent 100 messages
  in a room.
- `/room/<token>/messages/before/123` retrieves the most recent 100
  message events (i.e. post, edits, deletions) immediately preceding the
  *sequence value* 123.  (This is not a message id, but rather the
  messages `seqno` value).
- `/room/<token>/messages/since/456` retrieves the next 100 message
  events following `seqno=456`.
- all of the above except for the single message endpoint support a
  `?limit=42` parameter that allows values up to 256.

Message pinning (these all require *admin* privileges, not just
moderator permissions):
- POST `/room/<token>/pin/123` pins the message with id=123 to this
  room.  (Note that this adds a pinned; if there are other pinned
  messages you end up with multiple pinned messages).
- POST `/room/<token>/unpin/123` does what you'd expect.
- POST `/room/<token>/unpin/all` does what you'd expect.

- `/room/<token>/pollInfo/<id>` and `/room/<token>/messages/since/456`
  together replace legacy SOGS compact_poll *and* the need for periodic
  room info fetching.

  Ideally you'd poll everything in once by throwing these into a
  sequence request such as:

      [{'method': 'GET', 'path': '/room/room1/pollInfo/123'},
       {'method': 'GET', 'path': '/room/room2/pollInfo/456'},
       {'method': 'GET', 'path': '/room/room1/messages/since/789'},
       {'method': 'GET', 'path': '/room/room2/messages/since/1011'}]

    The first two give you room information such as the number of active
    users and your current permissions, and when room details change,
    the full room metadata (name, description, pinned_messages, image,
    moderators list, etc.)

    The second two give you new post updates (i.e. new posts, edits,
    deletions) for the two rooms.

    (It may sometimes be necessary to submit extra fetch requests if the
    messages-since endpoints give back a full set of 100 message
    updates).

Other notes:

- both the polling and full version of room details include the current
  permission keys,
  `read`/`write`/`upload`/`moderator`/`admin`/`global_moderator`/`global_admin`,
  which clients can use to update the UI as appropriate.

- Room "updates" and post "updated" are renamed to "message_sequence"
  and "seqno", respectively, to better describe what they are.  That is,
  these define the sequence of updates that a client needs: a new post
  counts as an update, but so does an edit to and existing post and a
  deletion.  The old name was rather confusing since there is also an
  `info_updates` on rooms which tracks changes to room details like
  name/image/etc.

- Simplified the active_users to report a single value plus the cutoff
  for that value (which is sogs-admin configurable).  Previously the API
  specified that it would return a default plus several different
  values, but that seems needlessly complex.  The cutoff, however, might
  be useful for an advanced page to know the time frame beyond which
  users are no longer considered "active".

- Added notes to file expiry that the short expiry until association
  with a post isn't implemented yet.

- Fix the user_permissions view not returning true for read/write/upload
  for moderator permissions in rooms if the permissions were not
  specifically applied to the moderator.  (Moderators/admins always have
  those permissions even if the defaults are false).

- Split up the moderators/admins list in room info so that regular users
  can distinguish between room moderators and admins, and so that
  mods/admins can distinguish between hidden mods/admins.

- Add extensive unit tests for everything above