### PR TITLE
Add support for IN clauses to db.query()

### DIFF
--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -685,6 +685,7 @@ class Room:
                         """,
                         r=self.id,
                         ids=tuple(message_ids[i : i + 50]),
+                        bind_expanding=['ids'],
                     )
                 )
 
@@ -700,11 +701,16 @@ class Room:
                             """,
                             u=deleter.id,
                             ids=ids,
+                            bind_expanding=['ids'],
                         )
                         if res.first()[0]:
                             raise BadPermission()
 
-                    query("DELETE FROM message_details WHERE id IN :ids", ids=ids)
+                    query(
+                        "DELETE FROM message_details WHERE id IN :ids",
+                        ids=ids,
+                        bind_expanding=['ids'],
+                    )
 
                     deleted += ids
                 i += 50


### PR DESCRIPTION
Expanding IN clauses in bindings with SQLAlchemy requires a little more
work (and the existing IN clauses were broken).

This expose the needed mechanics in the query() interface, used such as:
```Python
    db.query(
        "SELECT * FROM blah WHERE id IN :ids",
        ids=[1,2,3],
        bind_expanding=['ids']
    )
```