### PR TITLE
Bans, unbans

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -743,7 +743,8 @@ paths:
                     user must be a server-level moderator or admin.
                     
                     
-                    The ban applies immediately to all server requests as early as possible.
+                    The ban applies immediately to all server requests initiated by the user (not
+                    just room access).
                     
                     
                     Exclusive of `rooms`.
@@ -753,13 +754,9 @@ paths:
                   nullable: true
                   example: 86400
                   description: >
-                    How long the ban should apply, in seconds.  If there is an existing ban on the
-                    user in the given rooms this updates the existing expiry to the given value. If
-                    omitted or `null` then the ban does not expire.
-                    
-                    
-                    May only be used with the `rooms` argument; timeouts are not supported on global
-                    bans.
+                    How long the ban should apply, in seconds.  If omitted (or `null`) then the ban
+                    applies forever.  If an unban was previously scheduled then it is replaced (if a
+                    timeout is given) or deleted (if no timeout is provided).
             examples:
               tworooms:
                 summary: "1-day ban from two rooms"

--- a/api.yaml
+++ b/api.yaml
@@ -692,9 +692,14 @@ paths:
   /user/{sessionId}/ban:
     post:
       tags: [Users]
-      summary: Bans or unbans a user.
+      summary: Bans a user.
       description: >
-        Applies or removes a ban of a user from specific rooms, or from the server globally.
+        Applies a ban of a user from specific rooms, or from the server globally.
+        
+        
+        The invoking user must have moderator (or admin) permission in all given rooms when
+        specifying `rooms`, and must be a global server moderator (or admin) if using the `global`
+        parameter.
         
         
         Note that the given session ID does not have to exist: it is possible to preemptively ban
@@ -707,7 +712,7 @@ paths:
       parameters:
       - $ref: "#/components/parameters/pathSessionId"
       requestBody:
-        description: Details of the ban to apply. To unban a user, specify a negative timeout.
+        description: Details of the ban to apply.
         required: true
         content:
           application/json:
@@ -724,12 +729,21 @@ paths:
                     be a moderator (or admin) of all of the given rooms.
                     
                     
+                    You can specify a single element list `["*"]` to ban the user from all rooms on
+                    the server to which the calling user has moderator permissions.  This differs
+                    from a global ban in that it doesn't apply to non-moderator-permission rooms,
+                    nor does it apply to newly created rooms or non-room endpoints.
+                    
+                    
                     Exclusive of `global`.
                 global:
                   type: boolean
                   description: >
                     If true then apply the ban at the global level, i.e. server-wide. The invoking
                     user must be a server-level moderator or admin.
+                    
+                    
+                    The ban applies immediately to all server requests as early as possible.
                     
                     
                     Exclusive of `rooms`.
@@ -740,14 +754,12 @@ paths:
                   example: 86400
                   description: >
                     How long the ban should apply, in seconds.  If there is an existing ban on the
-                    user in the given rooms or globally this updates the existing expiry to the
-                    given value. If omitted or `null` the ban does not expire.
+                    user in the given rooms this updates the existing expiry to the given value. If
+                    omitted or `null` then the ban does not expire.
                     
-                    If this value is set to a negative value (`-1` is suggested) then any existing
-                    bans for this user are *removed* from the given rooms/server.  Note, however,
-                    that server bans and room bans are independent: removing a server-level ban does
-                    not remove room-specific bans, and removing a room-level ban will not grant room
-                    access to a user who also has a server-level ban.
+                    
+                    May only be used with the `rooms` argument; timeouts are not supported on global
+                    bans.
             examples:
               tworooms:
                 summary: "1-day ban from two rooms"
@@ -758,21 +770,77 @@ paths:
                 summary: "Permanent server ban"
                 value:
                   global: true
-                  timeout: null
-                  delete_all: true
-              unban:
-                summary: "Unban a user from a room"
-                value:
-                  rooms: ["lokinet"]
-                  global: false,
-                  timeout: -1
       responses:
         200:
           description: Ban applied successfully.
           content: {}
         403:
           description: >
-            Permission denied.  The user attempting to set the ban does not have moderator
+            Permission denied.  The user attempting to set the ban does not have the required
+            moderator permissions for one or more of the given rooms (or server moderator permission
+            for a global ban).
+          content: {}
+  /user/{sessionId}/unban:
+    post:
+      tags: [Users]
+      summary: Removes a user ban.
+      description: >
+        Removes a room-specific or global ban of a user.
+        
+        
+        Note that removing a room-specific ban does not affect an existing global ban, and removing
+        a global ban does not affect existing room-specific bans.
+      parameters:
+      - $ref: "#/components/parameters/pathSessionId"
+      requestBody:
+        description: Details of the ban to remove.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                rooms:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/RoomToken"
+                  minItems: 1
+                  description: >
+                    List of room tokens from which the ban should be removed (if present). The
+                    invoking user must be a moderator (or admin) of all of the given rooms.
+                    
+                    
+                    You can specify a single element list `["*"]` to unban the user from all rooms
+                    on the server to which the calling user has moderator permissions.  This isn't
+                    the same as removing a global ban; this just removes any room-specific bans that
+                    may currently apply from moderated rooms.
+                    
+                    
+                    Exclusive of `global`.
+                global:
+                  type: boolean
+                  description: >
+                    If true then remove a global server ban of this user. The invoking user must be
+                    a server-level moderator or admin.
+                    
+                    
+                    Exclusive of `rooms`.
+            examples:
+              tworooms:
+                summary: "Remove ban from two rooms"
+                value:
+                  rooms: ["session", "lokinet"]
+              permaban:
+                summary: "Remove server ban"
+                value:
+                  global: true
+      responses:
+        200:
+          description: Ban removed successfully.
+          content: {}
+        403:
+          description: >
+            Permission denied.  The user attempting to remove the ban does not have moderator
             permissions for one or more of the given rooms (or server moderator permission for a
             global ban).
           content: {}

--- a/sogs/db.py
+++ b/sogs/db.py
@@ -128,6 +128,7 @@ def database_init():
         create_message_details_deleter,
         check_for_hacks,
         seqno_etc_updates,
+        user_perm_future_updates,
     ):
         with transaction(conn):
             if migrate(conn):
@@ -474,6 +475,76 @@ FROM
     users CROSS JOIN rooms LEFT OUTER JOIN user_permission_overrides ON
         (users.id = user_permission_overrides."user" AND rooms.id = user_permission_overrides.room);
 """  # noqa: E501
+        )
+
+    return True
+
+
+def user_perm_future_updates(conn):
+    """
+    Break up user_permission_futures to not be (room,user) unique, and to move ban futures to a
+    separate table.
+    """
+
+    if 'user_ban_futures' in metadata.tables:
+        return False
+
+    logging.warning("Updating user_permission_futures")
+
+    if engine.name == 'sqlite':
+        # Under sqlite we have to drop and recreate the whole thing.  (Since we didn't have a
+        # release out that was using futures yet, we don't bother trying to migrate data).
+        conn.execute("DROP TABLE user_permission_futures")
+        conn.execute(
+            """
+CREATE TABLE user_permission_futures (
+    room INTEGER NOT NULL REFERENCES rooms ON DELETE CASCADE,
+    user INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
+    at FLOAT NOT NULL, /* when the change should take effect (unix epoch) */
+    read BOOLEAN, /* Set this value @ at, if non-null */
+    write BOOLEAN, /* Set this value @ at, if non-null */
+    upload BOOLEAN /* Set this value @ at, if non-null */
+)
+"""
+        )
+        conn.execute("CREATE INDEX user_permission_futures_at ON user_permission_futures(at)")
+        conn.execute(
+            """
+CREATE INDEX user_permission_futures_room_user ON user_permission_futures(room, user)
+"""
+        )
+
+        conn.execute(
+            """
+CREATE TABLE user_ban_futures (
+    room INTEGER REFERENCES rooms ON DELETE CASCADE,
+    user INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
+    at FLOAT NOT NULL, /* when the change should take effect (unix epoch) */
+    banned BOOLEAN NOT NULL /* if true then ban at `at`, if false then unban */
+);
+"""
+        )
+        conn.execute("CREATE INDEX user_ban_futures_at ON user_ban_futures(at)")
+        conn.execute("CREATE INDEX user_ban_futures_room_user ON user_ban_futures(room, user)")
+
+    else:  # postgresql
+        conn.execute(
+            """
+CREATE TABLE user_ban_futures (
+    room INTEGER NOT NULL REFERENCES rooms ON DELETE CASCADE,
+    "user" INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
+    at FLOAT NOT NULL, /* when the change should take effect (unix epoch) */
+    banned BOOLEAN NOT NULL /* if true then ban at `at`, if false then unban */
+);
+CREATE INDEX user_ban_futures_at ON user_ban_futures(at);
+CREATE INDEX user_ban_futures_room_user ON user_ban_futures(room, "user");
+
+INSERT INTO user_ban_futures (room, "user", at, banned)
+    SELECT room, "user", at, banned FROM user_permission_futures WHERE banned is NOT NULL;
+
+ALTER TABLE user_permission_futures DROP PRIMARY KEY;
+ALTER TABLE user_permission_futures DROP COLUMN banned;
+"""
         )
 
     return True

--- a/sogs/routes/users.py
+++ b/sogs/routes/users.py
@@ -12,6 +12,64 @@ from flask import abort, jsonify, g, Blueprint, request
 users = Blueprint('users', __name__)
 
 
+def extract_rooms_or_global(req, admin=True):
+    """
+    Extracts the rooms / global parameters from the request body checking them for validity and
+    expanding them as appropriate.
+
+    Throws a flask abort on failure, returns (rooms, global) which will be either ([list of Rooms],
+    None) for a room operation or (None, True) for a global operation.
+
+    admin specifies whether we require admin permission (if True) or just moderator permission,
+    either in all rooms specified, or globally.  (Similarly it affects what `rooms=['*']` expands
+    to).
+    """
+
+    room_tokens, global_ = req.get('rooms'), req.get('global', False)
+
+    if room_tokens and not isinstance(room_tokens, list):
+        app.logger.warning("Invalid request: rooms must be a list")
+        abort(http.BAD_REQUEST)
+
+    if room_tokens and global_:
+        app.logger.warning("Invalid moderator request: cannot specify both 'rooms' and 'global'")
+        abort(http.BAD_REQUEST)
+
+    if not room_tokens and not global_:
+        app.logger.warning("Invalid moderator request: neither 'rooms' nor 'global' specified")
+        abort(http.BAD_REQUEST)
+
+    if room_tokens:
+        if len(room_tokens) > 1 and '*' in room_tokens:
+            app.logger.warning("Invalid moderator request: room '*' must be the only rooms value")
+            abort(http.BAD_REQUEST)
+
+        if room_tokens == ['*']:
+            room_tokens = None
+
+        try:
+            rooms = mroom.get_rooms_with_permission(
+                g.user, tokens=room_tokens, moderator=True, admin=admin
+            )
+        except Exception as e:
+            # This is almost certainly a bad room token passed in:
+            app.logger.warning(f"Cannot get rooms for adding a moderator: {e}")
+            abort(http.NOT_FOUND)
+
+        if room_tokens:
+            if len(rooms) != len(room_tokens):
+                abort(http.FORBIDDEN)
+        elif not rooms:
+            abort(http.FORBIDDEN)
+
+        return (rooms, None)
+
+    if not g.user.global_moderator or (admin and not g.user.global_admin):
+        abort(http.FORBIDDEN)
+
+    return (None, True)
+
+
 @users.post("/user/<SessionID:sid>/moderator")
 @auth.user_required
 def set_mod(sid):
@@ -19,11 +77,8 @@ def set_mod(sid):
     user = User(session_id=sid)
 
     req = request.json
-    room_tokens, global_mod = req.get('rooms'), req.get('global', False)
 
-    if room_tokens and not isinstance(room_tokens, list):
-        app.logger.warning("Invalid request: room_tokens must be a list")
-        abort(http.BAD_REQUEST)
+    rooms, global_mod = extract_rooms_or_global(req)
 
     mod, admin, visible = (
         None if arg is None else bool(arg)
@@ -51,39 +106,11 @@ def set_mod(sid):
     # (False, True) -- removes admin, adds mod
     # (False, None) -- removes admin
 
-    with db.transaction():
-        if room_tokens:
-            if visible is None:
-                visible = True
+    if rooms:
+        if visible is None:
+            visible = True
 
-            if global_mod:
-                app.logger.warning(
-                    "Invalid moderator request: cannot specify both 'rooms' and 'global'"
-                )
-                abort(http.BAD_REQUEST)
-
-            if len(room_tokens) > 1 and '*' in room_tokens:
-                app.logger.warning(
-                    "Invalid moderator request: room '*' must be the only rooms value"
-                )
-                abort(http.BAD_REQUEST)
-
-            if room_tokens == ['*']:
-                room_tokens = None
-
-            try:
-                rooms = mroom.get_rooms_with_permission(g.user, tokens=room_tokens, admin=True)
-            except Exception as e:
-                # This is almost certainly a bad room token passed in:
-                app.logger.warning(f"Cannot get rooms for adding a moderator: {e}")
-                abort(http.BAD_REQUEST)
-
-            if room_tokens is not None:
-                if len(rooms) != len(room_tokens):
-                    abort(http.FORBIDDEN)
-            elif not rooms:
-                abort(http.FORBIDDEN)
-
+        with db.transaction():
             for room in rooms:
                 if (admin, mod) in ((True, None), (None, True)):
                     room.set_moderator(user, added_by=g.user, admin=admin, visible=visible)
@@ -98,18 +125,63 @@ def set_mod(sid):
                     app.logger.error("Internal error: unhandled mod/admin room case")
                     raise RuntimeError("Internal error: unhandled mod/admin room case")
 
-        else:  # global mod
-            if visible is None:
-                visible = False
+    else:  # global mod
+        if visible is None:
+            visible = False
 
-            if (admin, mod) in ((True, None), (None, True)):
-                user.set_moderator(added_by=g.user, admin=admin, visible=visible)
-            elif (admin, mod) == (None, False):
-                user.remove_moderator(removed_by=g.user)
-            elif (admin, mod) == (False, None):
-                user.remove_moderator(removed_by=g.user, remove_admin_only=True)
-            elif (admin, mod) == (False, True):
+        if (admin, mod) in ((True, None), (None, True)):
+            user.set_moderator(added_by=g.user, admin=admin, visible=visible)
+        elif (admin, mod) == (None, False):
+            user.remove_moderator(removed_by=g.user)
+        elif (admin, mod) == (False, None):
+            user.remove_moderator(removed_by=g.user, remove_admin_only=True)
+        elif (admin, mod) == (False, True):
+            with db.transaction():
                 user.remove_moderator(removed_by=g.user, remove_admin_only=True)
                 user.set_moderator(added_by=g.user, admin=bool(admin), visible=visible)
 
     return jsonify({})
+
+
+@users.post("/user/<SessionID:sid>/ban")
+@auth.user_required
+def ban_user(sid):
+
+    user = User(session_id=sid)
+    req = request.json
+    rooms, global_ban = extract_rooms_or_global(req, admin=False)
+
+    timeout = req.get('timeout')
+    if timeout is not None and not isinstance(timeout, int) and not isinstance(timeout, float):
+        app.logger.warning("Invalid ban request: timeout must be numeric")
+        abort(http.BAD_REQUEST)
+
+    if timeout and global_ban:
+        app.logger.warning("Invalid ban request: global server bans do not support timeouts")
+        abort(http.BAD_REQUEST)
+
+    if rooms:
+        with db.transaction():
+            for room in rooms:
+                room.ban_user(to_ban=user, mod=g.user, timeout=timeout)
+    else:
+        user.ban(banned_by=g.user)
+
+    return {}
+
+
+@users.post("/user/<SessionID:sid>/unban")
+@auth.user_required
+def unban_user(sid):
+
+    user = User(session_id=sid)
+    rooms, global_ban = extract_rooms_or_global(request.json, admin=False)
+
+    if rooms:
+        with db.transaction():
+            for room in rooms:
+                room.unban_user(to_unban=user, mod=g.user)
+    else:
+        user.unban(unbanned_by=g.user)
+
+    return {}

--- a/sogs/routes/users.py
+++ b/sogs/routes/users.py
@@ -156,16 +156,12 @@ def ban_user(sid):
         app.logger.warning("Invalid ban request: timeout must be numeric")
         abort(http.BAD_REQUEST)
 
-    if timeout and global_ban:
-        app.logger.warning("Invalid ban request: global server bans do not support timeouts")
-        abort(http.BAD_REQUEST)
-
     if rooms:
         with db.transaction():
             for room in rooms:
                 room.ban_user(to_ban=user, mod=g.user, timeout=timeout)
     else:
-        user.ban(banned_by=g.user)
+        user.ban(banned_by=g.user, timeout=timeout)
 
     return {}
 

--- a/sogs/schema.pgsql
+++ b/sogs/schema.pgsql
@@ -367,11 +367,22 @@ CREATE TABLE user_permission_futures (
     at FLOAT NOT NULL, /* when the change should take effect (unix epoch) */
     read BOOLEAN, /* Set this value @ at, if non-null */
     write BOOLEAN, /* Set this value @ at, if non-null */
-    upload BOOLEAN, /* Set this value @ at, if non-null */
-    banned BOOLEAN, /* Set this value @ at, if non-null */
-    PRIMARY KEY(room, "user")
+    upload BOOLEAN /* Set this value @ at, if non-null */
 );
 CREATE INDEX user_permissions_future_at ON user_permission_futures(at);
+CREATE INDEX user_permissions_future_room_user ON user_permission_futures(room, "user");
+
+-- Similar to the above, but for ban/unbans.  For example to implement a 2-day ban you would set
+-- their user_permissions.banned to TRUE then add a row here with banned = FALSE to schedule the
+-- unban.  (You can also schedule a future *ban* here, but the utility of that is less clear).
+CREATE TABLE user_ban_futures (
+    room INTEGER NOT NULL REFERENCES rooms ON DELETE CASCADE,
+    "user" INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
+    at FLOAT NOT NULL, /* when the change should take effect (unix epoch) */
+    banned BOOLEAN NOT NULL /* if true then ban at `at`, if false then unban */
+);
+CREATE INDEX user_ban_futures_at ON user_ban_futures(at);
+CREATE INDEX user_ban_futures_room_user ON user_ban_futures(room, "user");
 
 
 -- Nonce tracking to prohibit request signature nonce reuse (thus prevent replay attacks)

--- a/sogs/schema.sqlite
+++ b/sogs/schema.sqlite
@@ -322,16 +322,27 @@ FROM
 -- Or to implement a join delay you could set room defaults to false then insert a value here to be
 -- applied after a delay.
 CREATE TABLE user_permission_futures (
-    room INTEGER NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
-    user INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    room INTEGER NOT NULL REFERENCES rooms ON DELETE CASCADE,
+    user INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
     at FLOAT NOT NULL, /* when the change should take effect (unix epoch) */
     read BOOLEAN, /* Set this value @ at, if non-null */
     write BOOLEAN, /* Set this value @ at, if non-null */
-    upload BOOLEAN, /* Set this value @ at, if non-null */
-    banned BOOLEAN, /* Set this value @ at, if non-null */
-    PRIMARY KEY(room, user)
-) WITHOUT ROWID;
-CREATE INDEX user_permissions_future_at ON user_permission_futures(at);
+    upload BOOLEAN /* Set this value @ at, if non-null */
+);
+CREATE INDEX user_permission_futures_at ON user_permission_futures(at);
+CREATE INDEX user_permission_futures_room_user ON user_permission_futures(room, "user");
+
+-- Similar to the above, but for ban/unbans.  For example to implement a 2-day ban you would set
+-- their user_permissions.banned to TRUE then add a row here with banned = FALSE to schedule the
+-- unban.  (You can also schedule a future *ban* here, but the utility of that is less clear).
+CREATE TABLE user_ban_futures (
+    room INTEGER REFERENCES rooms ON DELETE CASCADE,
+    user INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
+    at FLOAT NOT NULL, /* when the change should take effect (unix epoch) */
+    banned BOOLEAN NOT NULL /* if true then ban at `at`, if false then unban */
+);
+CREATE INDEX user_ban_futures_at ON user_ban_futures(at);
+CREATE INDEX user_ban_futures_room_user ON user_ban_futures(room, user);
 
 
 -- Nonce tracking to prohibit request signature nonce reuse (thus prevent replay attacks)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,16 @@ def room(db):
 
 
 @pytest.fixture
+def room2(db):
+    """
+    Creates a test room, typically used with `room` when two separate rooms are needed.  Note that
+    `mod` and `admin` (if used) are only a mod and admin of `room`, not `room2`
+    """
+
+    return Room.create('room2', name='Room 2', description='Test suite testing room2')
+
+
+@pytest.fixture
 def user(db):
     """
     Generates an ordinary user without any special privileges.  Returns a subclass of a model.User

--- a/tests/test_room_routes.py
+++ b/tests/test_room_routes.py
@@ -9,9 +9,8 @@ from util import pad32
 from request import sogs_get, sogs_post, sogs_put
 
 
-def test_list(client, room, user, user2, admin, mod, global_mod, global_admin):
+def test_list(client, room, room2, user, user2, admin, mod, global_mod, global_admin):
 
-    room2 = Room.create('room2', name='Room 2', description='Test suite testing room2')
     room2.default_write = False
     room2.default_upload = False
 

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -6,22 +6,22 @@ from sogs.model.file import File
 from util import pad32
 
 
-def test_create(room):
+def test_create(room, room2):
 
-    r2 = Room.create('test-room-2', name='Test room 2', description='Test suite testing room')
     r3 = Room.create('Test_Room-3', name='Test room 3', description='Test suite testing room3')
 
     rooms = get_rooms()
 
     assert len(rooms) == 3
 
-    assert rooms[0].token == 'test-room'
-    assert rooms[0].name == 'Test room'
-    assert rooms[0].description == 'Test suite testing room'
+    assert rooms[0].token == 'room2'
+    assert rooms[0].id == room2.id
+    assert rooms[0].name == 'Room 2'
+    assert rooms[0].description == 'Test suite testing room2'
 
-    assert rooms[1].token == 'test-room-2'
-    assert rooms[1].id == r2.id
-    assert rooms[1].name == 'Test room 2'
+    assert rooms[1].token == 'test-room'
+    assert rooms[1].id == room.id
+    assert rooms[1].name == 'Test room'
     assert rooms[1].description == 'Test suite testing room'
 
     assert rooms[2].token == 'Test_Room-3'
@@ -30,7 +30,7 @@ def test_create(room):
     assert rooms[2].description == 'Test suite testing room3'
 
     with pytest.raises(exc.AlreadyExists):
-        Room.create('test-room-2', name='x', description=None)
+        Room.create('room2', name='x', description=None)
 
 
 def test_token_insensitive(room):
@@ -53,12 +53,10 @@ def test_token_insensitive(room):
         Room(token='Test-Ro-om')
 
 
-def test_delete(room):
-    r2 = Room.create('test-room-2', name='Test room 2', description='Test suite testing room')
-
+def test_delete(room, room2):
     assert len(get_rooms()) == 2
 
-    r2.delete()
+    room2.delete()
 
     rooms = get_rooms()
     assert len(rooms) == 1
@@ -553,7 +551,7 @@ def test_image_expiries(room, user):
     assert f1.expiry is not None
 
 
-def test_pinning(room, user, mod, admin, global_admin, no_rate_limit):
+def test_pinning(room, room2, user, mod, admin, global_admin, no_rate_limit):
     msgs = [room.add_post(user, f"data {i}".encode(), pad32(f"sig {i}")) for i in range(1, 10)]
 
     with pytest.raises(exc.BadPermission):
@@ -609,8 +607,7 @@ def test_pinning(room, user, mod, admin, global_admin, no_rate_limit):
         room.pin(123, admin)
 
     # Pinning some other room's message should fail
-    r2 = Room.create('test-room-2', name='Test room 2', description='Test suite testing room')
     with pytest.raises(exc.NoSuchPost):
-        r2.pin(7, global_admin)
+        room2.pin(7, global_admin)
 
-    assert not r2.pinned_messages
+    assert not room2.pinned_messages


### PR DESCRIPTION
Allows adding bans, ban timeouts, and unbanning at both the room and server level.

Timeouts revealed a deficiency in the user permission futures table that would be difficult to deal with, so I split up permission futures and ban futures into two separate tables which makes things quite a bit simpler -- *and* allows global bans to have an expiry, which wasn't possible before.