### PR TITLE
Room info update endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -66,6 +66,67 @@ paths:
             Forbidden. Returned if the user is banned from the room or otherwise does not have read
             access to the room.
           content: {}
+    put:
+      tags: [Rooms]
+      summary: Updates room details/settings.
+      parameters:
+        - $ref: "#/components/parameters/pathRoomToken"
+      requestBody:
+        description:
+          JSON body containing the room details to update.  Any field can be omitted to leave it at
+          its current value.  The invoking user must have admin permissions in the room to call this
+          method.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: >
+                    New user-displayed single-line name/title of this room.  UTF-8 encoded;
+                    newlines, tabs and other control characters (i.e. all codepoints below \u0020)
+                    will be stripped out.
+                  maxLength: 100
+                  example: "My New Room"
+                description:
+                  type: string
+                  description: >
+                    Long description to show to users, typically in smaller text below the room
+                    name.  UTF-8 encoded, and permits newlines, tabs; other control characters below
+                    \u0020 will be stripped out.  Can be `null` or an empty string to remove the
+                    description entirely.
+                  example: "This is the room for all things new.\n\nHi mom!"
+                default_read:
+                  type: boolean
+                  description: >
+                    Sets the default "read" permission (if true: users can read messages) for users
+                    in this room who do not otherwise have specific permissions applied.
+                  example: true
+                default_write:
+                  type: boolean
+                  description: >
+                    Sets the default "write" permission (if true: users can post messages) for users
+                      in the room who do not otherwise have specific permissions applied.
+                  example: false
+                default_upload:
+                  type: boolean
+                  description: >
+                    Sets the default "upload" permission (if true: users can post messages
+                      containing attachments) for users in the room who do not otherwise have
+                      specific permissions applied.
+                  example: false
+      responses:
+        200:
+          description: The room was successfully updated.  Currently returns an empty json dict.
+          content:
+            application/json:
+              schema:
+                type: object
+        403:
+          description: Forbidden.  Returned if the user does not have admin permission in this room.
+
   /room/{roomToken}/pollInfo/{info_updated}:
     get:
       tags: [Rooms]

--- a/api.yaml
+++ b/api.yaml
@@ -184,6 +184,12 @@ paths:
                     $ref: "#/components/schemas/Room/properties/global_moderator"
                   global_admin:
                     $ref: "#/components/schemas/Room/properties/global_admin"
+                  default_read:
+                    $ref: "#/components/schemas/Room/properties/default_read"
+                  default_write:
+                    $ref: "#/components/schemas/Room/properties/default_write"
+                  default_upload:
+                    $ref: "#/components/schemas/Room/properties/default_upload"
                   details:
                     allOf:
                       - $ref: "#/components/schemas/Room"
@@ -1526,6 +1532,26 @@ components:
             Whether the requesting user has permissions to upload attachments to messages posted to
             the room.  (Note that changes to this property do not cause an `info_update` increment.)
           example: true
+        default_read:
+          type: boolean
+          description: >
+            Whether new users have permission to read posts in this room by default.  This property
+            is only returned if the calling user has moderator/admin permissions.
+          example: true
+        default_write:
+          type: boolean
+          description: >
+            Whether new users have permission to write posts in this room by default.  This property
+            is only returned if the calling user has moderator/admin permissions.
+          example: true
+        default_upload:
+          type: boolean
+          description: >
+            Whether new users have permission to upload attachments to posts in this room by
+            default.  This property is only returned if the calling user has moderator/admin
+            permissions.
+          example: true
+
     Message:
       title: The content of a posted message
       type: object
@@ -1637,9 +1663,6 @@ components:
       description: "Session ID of a user."
       schema:
         $ref: "#/components/schemas/SessionID"
-        
-
-
 
   securitySchemes:
     pubkey:

--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -213,9 +213,10 @@ class Room:
     @name.setter
     def name(self, name: str):
         """Sets the room's human-readable name."""
-        with db.transaction():
-            query("UPDATE rooms SET name = :n WHERE id = :r", r=self.id, n=name)
-            self._refresh()
+        if name != self._name:
+            with db.transaction():
+                query("UPDATE rooms SET name = :n WHERE id = :r", r=self.id, n=name)
+                self._refresh()
 
     @property
     def description(self):
@@ -225,9 +226,10 @@ class Room:
     @description.setter
     def description(self, desc):
         """Sets the room's human-readable description."""
-        with db.transaction():
-            query("UPDATE rooms SET description = :d WHERE id = :r", r=self.id, d=desc)
-            self._refresh()
+        if desc != self._description:
+            with db.transaction():
+                query("UPDATE rooms SET description = :d WHERE id = :r", r=self.id, d=desc)
+                self._refresh()
 
     @property
     def image_id(self):
@@ -322,25 +324,28 @@ class Room:
     def default_read(self, read: bool):
         """Sets the default read permission of the room"""
 
-        with db.transaction():
-            query("UPDATE rooms SET read = :read WHERE id = :r", r=self.id, read=read)
-            self._refresh(perms=True)
+        if read != self._default_read:
+            with db.transaction():
+                query("UPDATE rooms SET read = :read WHERE id = :r", r=self.id, read=read)
+                self._refresh(perms=True)
 
     @default_write.setter
     def default_write(self, write: bool):
         """Sets the default write permission of the room"""
 
-        with db.transaction():
-            query("UPDATE rooms SET write = :write WHERE id = :r", r=self.id, write=write)
-            self._refresh(perms=True)
+        if write != self._default_write:
+            with db.transaction():
+                query("UPDATE rooms SET write = :write WHERE id = :r", r=self.id, write=write)
+                self._refresh(perms=True)
 
     @default_upload.setter
     def default_upload(self, upload: bool):
         """Sets the default upload permission of the room"""
 
-        with db.transaction():
-            query("UPDATE rooms SET upload = :upload WHERE id = :r", r=self.id, upload=upload)
-            self._refresh(perms=True)
+        if upload != self._default_upload:
+            with db.transaction():
+                query("UPDATE rooms SET upload = :upload WHERE id = :r", r=self.id, upload=upload)
+                self._refresh(perms=True)
 
     def active_users(self, cutoff=config.ROOM_DEFAULT_ACTIVE_THRESHOLD * 86400):
         """

--- a/sogs/routes/rooms.py
+++ b/sogs/routes/rooms.py
@@ -18,7 +18,6 @@ def get_one_room(room):
     rr = {
         'token': room.token,
         'name': room.name,
-        'description': room.description,
         'info_updates': room.info_updates,
         'message_sequence': room.message_sequence,
         'created': room.created,
@@ -26,12 +25,13 @@ def get_one_room(room):
         'active_users_cutoff': int(config.ROOM_DEFAULT_ACTIVE_THRESHOLD * 86400),
         'moderators': mods,
         'admins': admins,
-        'moderator': room.check_moderator(g.user),
-        'admin': room.check_admin(g.user),
         'read': room.check_read(g.user),
         'write': room.check_write(g.user),
         'upload': room.check_upload(g.user),
     }
+
+    if room.description is not None:
+        rr['description'] = room.description
 
     if room.image_id is not None:
         rr['image_id'] = room.image_id
@@ -45,6 +45,13 @@ def get_one_room(room):
     if h_admins:
         rr['hidden_admins'] = h_admins
 
+    if room.check_moderator(g.user):
+        rr['moderator'] = True
+        rr['default_read'] = room.default_read
+        rr['default_write'] = room.default_write
+        rr['default_upload'] = room.default_upload
+    if room.check_admin(g.user):
+        rr['admin'] = True
     if g.user:
         if g.user.global_moderator:
             rr['global_moderator'] = True
@@ -126,8 +133,6 @@ def poll_room_info(room, info_updated):
     result = {
         'token': room.token,
         'active_users': room.active_users(),
-        'moderator': room.check_moderator(g.user),
-        'admin': room.check_admin(g.user),
         'read': room.check_read(g.user),
         'write': room.check_write(g.user),
         'upload': room.check_upload(g.user),
@@ -136,6 +141,13 @@ def poll_room_info(room, info_updated):
     if room.info_updates != info_updated:
         result['details'] = get_one_room(room)
 
+    if room.check_moderator(g.user):
+        result['moderator'] = True
+        result['default_read'] = room.default_read
+        result['default_write'] = room.default_write
+        result['default_upload'] = room.default_upload
+    if room.check_admin(g.user):
+        result['admin'] = True
     if g.user:
         if g.user.global_moderator:
             result['global_moderator'] = True

--- a/sogs/routes/rooms.py
+++ b/sogs/routes/rooms.py
@@ -71,11 +71,8 @@ BAD_DESCRIPTION_CHARS = {c: None for c in range(32) if not (0x09 <= c <= 0x0A)}
 
 
 @rooms.put("/room/<Room:room>")
-@auth.user_required
+@auth.admin_required
 def update_room(room):
-
-    if not room.check_admin(g.user):
-        abort(http.FORBIDDEN)
 
     req = request.json
 


### PR DESCRIPTION
Adds `PUT /room/{token}` endpoint to accept a new name, description, and default_{read,write,upload} settings.

Also fixes some incorrect returned values (including fields with `false` values instead of omitting them), and exposes the default_read/write/upload values to room info for moderators.