### PR TITLE
Add new config Boolean, http_show_index, for room directory display.

### DIFF
--- a/sogs.ini.sample
+++ b/sogs.ini.sample
@@ -43,6 +43,12 @@
 ;omq_internal = ipc://./omq.sock
 
 
+; Whether we should show an index of public rooms on the root URL when visited by a
+; browser.
+;
+;http_show_index = yes
+
+
 ; Whether we should show recent messages for public rooms on the sogs room page when visited by a
 ; browser.
 ;

--- a/sogs/config.py
+++ b/sogs/config.py
@@ -14,6 +14,7 @@ DB_URL = 'sqlite:///sogs.db'
 DB_SCHEMA_FILE = 'schema.sql'  # Not configurable, just a constant
 KEY_FILE = 'key_x25519'
 URL_BASE = 'http://example.net'
+HTTP_SHOW_INDEX = True
 HTTP_SHOW_RECENT = True
 OMQ_LISTEN = 'tcp://*:22028'
 OMQ_INTERNAL = 'ipc://./omq.sock'
@@ -83,6 +84,7 @@ def load_config():
                 lambda x: [y for y in x.splitlines() if len(y)],
             ),
             'omq_internal': ('OMQ_INTERNAL', lambda x: re.search('^(?:tcp|ipc)://.', x)),
+            'http_show_index': bool_opt('HTTP_SHOW_INDEX'),
             'http_show_recent': bool_opt('HTTP_SHOW_RECENT'),
         },
         'files': {

--- a/sogs/routes/__init__.py
+++ b/sogs/routes/__init__.py
@@ -30,6 +30,8 @@ def serve_index():
     rooms = get_readable_rooms()
     if len(rooms) == 0:
         return render_template('setup.html')
+    if not config.HTTP_SHOW_INDEX:
+        abort(http.FORBIDDEN)
     return render_template(
         "index.html", url_base=config.URL_BASE, rooms=rooms, pubkey=crypto.server_pubkey_hex
     )


### PR DESCRIPTION
'http_show_index = No' disables the default behaviour of displaying a
directory of public rooms when the root server URL is visited using a
browser.