### PR TITLE
v4 onion requests

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -11,6 +11,7 @@ local default_deps = [
   'python3-uwsgidecorators',
   'python3-flask',
   'python3-cryptography',
+  'python3-pycryptodome',
   'python3-nacl',
   'python3-pil',
   'python3-protobuf',

--- a/api.yaml
+++ b/api.yaml
@@ -1346,7 +1346,7 @@ paths:
         200:
           $ref: "#/paths/~1batch/post/responses/200"
 
-  /oxen/v3/lsrpc:
+  /oxen/v4/lsrpc:
     post:
       tags: [Onion]
       summary: "Endpoint for submitting an encrypted onion request"
@@ -1359,66 +1359,54 @@ paths:
           the onion encryption layer; the onion encryption payload itself is documented elsewhere.
         required: true
         content:
-          application/json:
+          application/octet-stream:
             schema:
-              type: object
-              required: [endpoint, method, headers]
-              properties:
-                method:
-                  type: string
-                  description: "The request method type as a string, i.e. `GET`, `POST`, `PUT`, `DELETE`."
-                endpoint:
-                  type: string
-                  description: >
-                    The request path, e.g. `/room/123/messages/since/45678`.  This name should be
-                    the full path beginning with a `/`; methods without a leading / are
-                    interpreted as legacy endpoints for older versions of Session and should not
-                    be used.
-                headers:
-                  type: object
-                  description: >
-                    HTTP headers for the request; should usually include the pubkey, nonce,
-                    timestamp, and signature headers (`X-SOGS-Pubkey`, etc.), and sometimes a
-                    `Content-Type` header (the latter, if omitted, defaults to `application/json`
-                    if using `body`, and `application/octet-stream` if using `body_binary`).
-                body:
-                  description: >
-                    Request body of the onion request.  This is typically used for text-based
-                    values (such as JSON requests).  Exclusive of `body_binary`.  Not accepted for
-                    `GET` requests.
-                  type: string
-                body_binary:
-                  description: >
-                    Request body for a onion request to a binary endpoint, with the body encoded
-                    in base64.  Exclusive of `body`.  Not accepted for `GET` requests.
-                    
-                    
-                    The endpoint will be called with the *decoded* byte value as its body, thus
-                    allowing you to POST to endpoints that require binary data (such as file
-                    uploads).  Note that when using the Content-Type header defaults to
-                    `application/octet-stream`.
-                    
-                    
-                    Note that when including a signature in the `X-SOGS-Signature` header, the
-                    signature must use the decoded byte value of the body, *not* the encoded
-                    base64 value.
-                    
-                    
-                    This is somewhat wasteful because of the overhead of base64-encoding, but is a
-                    limitation of onion requests.
-                  type: string
-                  format: byte
+              type: string
+              format: binary
+              description: >
+                The onion request data.  This is encoded/encrypted in multiple layers, as follows.
+                
+                
+                The data is first constructed as one or two parts: the first part is json contains
+                request metadata with fields:
+                - method -- "GET", "POST", etc. of the subrequest
+                - endpoint -- the subrequest endpoint, e.g. `/room/some-room/messages/since/123`
+                - headers -- request headers, typically containing X-SOGS-* auth info and, for
+                  POST/PUT requests, a Content-Type.
+                
+                
+                The second part is the request body, in bytes (only for POST/PUT requests).
+                
+                
+                These two pieces are encoded as a one- or two-string bencoded list, which has format:
+                
+                
+                `l123:jsone` or `l123:json456:bodye` where 123 is the length of the json and 456 is
+                the length of the body, if the request has a body.  (Both strings are byte strings).
+                
+                
+                This data is then encrypted using onion-request style encryption; see the
+                oxen-storage-server for details on how this is done.
       responses:
         200:
           description: >
-            Request completed.  The actual response will be base64-encoded and encrypted.  For
-            requests that fail with an HTTP response (i.e. other than 200) the response will
-            base64+decrypt to the json value `{"status_code": N}` where `N` is the integer error
-            code that occurred (e.g. 404).
+            Onion request completed.  The subrequest response will be encoded in a two-string
+            bencoded list (see the request details for the encoding specifics) where the first
+            string contains the response metadata as json with keys:
             
-            For successful (i.e. 200) responses the returned value is whatever the body of the
-            request returned.  (Returning headers via onion requests is not supported.)
-
+            
+            - code -- the HTTP response code of the subrequest, e.g. 200, 404
+            - headers -- a dict of HTTP response headers; the header name keys are always
+              lower-cased.
+            
+            
+            The second part is the response body bytes; as in HTTP, interpreting this depends on the
+            `content-type` header in the `headers` metadata, and the details of the invoked
+            endpoint.
+            
+            
+            These two byte strings are bencoded, and then the bencoded data is encrypted using the
+            same ephemeral key and encryption type as was used in the request.
 
 components:
   schemas:

--- a/sogs/routes/general.py
+++ b/sogs/routes/general.py
@@ -143,15 +143,13 @@ def batch(_sequential=False):
     response = []
     for method, path, headers, json, body in subreqs:
         try:
-            subres = make_subrequest(method, path, headers=headers, body=body, json=json)
+            subres, headers = make_subrequest(method, path, headers=headers, body=body, json=json)
             if subres.content_type == "application/json":
                 body = subres.get_json()
             else:
                 body = subres.get_data()
 
-            response.append(
-                {"code": subres.status_code, "content-type": subres.content_type, "body": body}
-            )
+            response.append({"code": subres.status_code, "headers": headers, "body": body})
         except Exception as e:
             app.logger.warning(f"Batch subrequest failed: {e}")
             response.append(

--- a/sogs/routes/onion_request.py
+++ b/sogs/routes/onion_request.py
@@ -9,65 +9,81 @@ from .subrequest import make_subrequest
 onion_request = Blueprint('onion_request', __name__)
 
 
-def handle_onionreq_plaintext(body):
+def handle_v3_onionreq_plaintext(body):
     """
-    Handles a decrypted onion request; this injects a subrequest to process it then returns the
+    Handles a decrypted v3 onion request; this injects a subrequest to process it then returns the
     result of that subrequest (as bytes).
 
-    Note that this does not throw: if errors occur we map them into "success" responses with a body
-    of {"status_code":xxx} as onion requests have no ability at all to signal a request failure.
+    The body must be JSON containing two always-required keys:
+
+    - "endpoint" -- the HTTP endpoint to invoke (e.g. "/room/some-room").
+    - "method" -- the HTTP method (e.g. "POST", "GET")
+
+    Plus, when method is POST or PUT, the required field:
+
+    - "body" -- the request body for POST/PUT requests
+
+    Optional keys that may be included are:
+    - "headers" -- optional dict of HTTP headers for the request.  Header names are
+                   case-insensitive (i.e. `X-Foo` and `x-FoO` are equivalent).
+
+    If "endpoint" does not start with a "/" then the request is a legacy endpoint request, and two
+    things happen:
+    - "/legacy/" will be prepended to the endpoint.  E.g. "endpoint":"rooms/ROOM/image" goes to the
+      "/legacy/rooms/ROOM/image" endpoint in pysogs.
+    - we will look "auth_code" in the json -- if specified, this is equivalent to specifying the
+      "Authorization" header with the given value (this is used for user authentication for legacy
+      sogs requests.)
+
+    When returning, we invoke the subrequest and then, if it returns a 200 response code, we take
+    the response body, encrypt it, and then base64 the encrypted body and send that back as the
+    response body of the onion request.
+
+    If the subrequest returned a non-200 response code then instead of the returned body we return
+    `{"status_code":xxx}` (where xxx is the numeric status code) and encrypt/base64 encode that.
+
+    Response headers are completely ignored, as are bodies of non-200 responses.
+
+    This is deprecated because it amplifies request and response sizes, it doesn't allow non-json
+    requests, and it drops pertinent request information (such as response headers and error
+    bodies).  Prefer v4 requests which do not have these drawbacks.
     """
+
     try:
-        if body.startswith(b'{'):
-            # JSON input
-            req = json.loads(body)
-            endpoint, method, auth_code = req['endpoint'], req['method'], req.get("auth_code")
-            subreq_headers = {k.lower(): v for k, v in req.get('headers', {}.items()).items()}
+        if not body.startswith(b'{'):
+            raise RuntimeError("Invalid v3 onion request body: expected JSON object")
 
-            if method in http.BODY_METHODS:
-                if 'body_binary' in req:
-                    subreq_body = utils.decode_base64(req['body_binary'])
-                else:
-                    subreq_body = req.get('body', '').encode()
-                ct = subreq_headers.pop(
-                    'content-type',
-                    'application/octet-stream' if 'body_binary' in req else 'application/json',
-                )
-            else:
-                subreq_body = None
-                # Android bug workaround: Android Session (at least up to v1.11.12) sends a body on
-                # GET requests with a 4-character string "null" when it should send no body.
-                if 'body' in req and len(req['body']) == 4 and req['body'] == 'null':
-                    del req['body']
+        req = json.loads(body)
+        endpoint, method, auth_code = req['endpoint'], req['method'], req.get("auth_code")
+        subreq_headers = {k.lower(): v for k, v in req.get('headers', {}).items()}
 
-                if 'body' in req and len(req['body']) or 'body_binary' in req:
-                    raise RuntimeError(
-                        "Invalid {} {} request: request must not contain a body".format(
-                            method, endpoint
-                        )
-                    )
-
-        elif body.startswith(b'd'):
-            raise RuntimeError("Bencoded onion requests not implemented yet")
-
+        if method in http.BODY_METHODS:
+            subreq_body = req.get('body', '').encode()
         else:
-            raise RuntimeError(
-                "Invalid onion request body: expected JSON object or a bt-encoded dict"
-            )
+            subreq_body = None
+            # Android bug workaround: Android Session (at least up to v1.11.12) sends a body on
+            # GET requests with a 4-character string "null" when it should send no body.
+            if 'body' in req and len(req['body']) == 4 and req['body'] == 'null':
+                del req['body']
 
-        # Legacy onion request targets don't start with /; we may them to `/target/whatever` (mainly
-        # to help organize them here).
+            if 'body' in req and req['body']:
+                raise RuntimeError(
+                    "Invalid {} {} request: request must not contain a body".format(
+                        method, endpoint
+                    )
+                )
+
         if not endpoint.startswith('/'):
             endpoint = '/legacy/' + endpoint
             if auth_code:
                 subreq_headers["Authorization"] = auth_code
 
-        response = make_subrequest(
+        response, _headers = make_subrequest(
             method,
             endpoint,
             headers=subreq_headers,
             body=subreq_body,
-            content_type=ct,
+            content_type='application/json',
             user_reauth=True,  # Because onion requests have auth headers on the *inside*
         )
 
@@ -84,19 +100,195 @@ def handle_onionreq_plaintext(body):
         return json.dumps({'status_code': http.BAD_REQUEST}).encode()
 
 
+def handle_v4_onionreq_plaintext(body):
+    """
+    Handles a decrypted v4 onion request; this injects a subrequest to process it then returns the
+    result of that subrequest.  In contrast to v3, it is more efficient (particularly for binary
+    input or output) and allows using endpoints that return headers or bodies with non-2xx response
+    codes.
+
+    The body of a v4 request (post-decryption) is a bencoded list containing exactly 1 or 2 byte
+    strings: the first byte string contains a json object containing the request metadata which has
+    three required fields:
+
+    - "endpoint" -- the HTTP endpoint to invoke (e.g. "/room/some-room").
+    - "method" -- the HTTP method (e.g. "POST", "GET")
+    - "headers" -- dict of HTTP headers for the request.  Header names are case-insensitive (i.e.
+      `X-Foo` and `x-FoO` are equivalent).
+
+    Unlike v3 requests, endpoints must always start with a /.  (If a legacy endpoint "whatever"
+    needs to be accessed through a v4 request for some reason then it can be accessed via the
+    "/legacy/whatever" endpoint).
+
+    The "headers" field typically carries X-SOGS-* authentication headers as well as fields like
+    Content-Type.  Note that, unlike v3 requests, the Content-Type does *not* have any default and
+    should also be specified, often as `application/json`.  Unlike HTTP requests, Content-Length is
+    not required and will be ignored if specified; the content-length is always determined from the
+    provided body.
+
+    The second byte string in the request, if present, is the request body in raw bytes and is
+    required for POST and PUT requests and must not be provided for GET/DELETE requests.
+
+    Bencoding details:
+        A full bencode library can be used, but the format used here is deliberately meant to be as
+        simple as possible to implement without a full bencode library on hand.  The format of a
+        byte string is `N:` where N is a decimal number (e.g. `123:` starts a 123-byte string),
+        followed by the N bytes.  A list of strings starts with `l`, contains any number of encoded
+        byte strings, followed by `e`.  (Full bencode allows dicts, integers, and list/dict
+        recursion, but we do not use any of that for v4 bencoded onion requests).
+
+    For example, the request:
+
+        GET /room/some-room
+        Some-Header: 12345
+
+    would be encoded as:
+
+        l79:{"method":"GET","endpoint":"/room/some-room","headers":{"Some-Header":"12345"}}e
+
+    that is: a list containing a single 79-byte string.  A POST request such as:
+
+        POST /some/thing
+        Some-Header: a
+
+        post body here
+
+    would be encoded as the two-string bencoded list:
+
+        l72:{"method":"POST","endpoint":"/some/thing","headers":{"Some-Header":"a"}}14:post body heree
+            ^^^^^^^^72-byte request info json^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^body^^^^^
+
+    The return value of the request is always a 2-part bencoded list where the first part contains
+    response metadata and the second contains the response body.  The response metadata is a json
+    object containing:
+    - "code" -- the numeric HTTP response code (e.g. 200, 403); and
+    - "headers" -- a json object of header names to values.  Note that, since HTTP headers are
+      case-insensitive, the header names are always returned as lower-case, and we strip out the
+      'content-length' header (since it is already encoded in the length of the body part).
+
+    For example, a simple json request response might be the two parts:
+
+    - `{"code":200,"headers":{"content-type":"application/json"}}`
+    - `{"id": 123}`
+
+    encoded as:
+
+        l58:{"code":200,"headers":{"content-type":"application/json"}}11:{"id": 123}e
+
+    A more complicated request, for example for a file download, might return binary content such as:
+
+    - `{"code":200,"headers":{"content-type":"application/octet-stream","content-disposition":"attachment; filename*=UTF-8''filename.txt"}}`
+    - `My file contents`
+
+    i.e. encoded as `l132:{...the json above...}16:My file contentse`
+
+    Error responses (e.g. a 403) are not treated specially; that is: they still have a "code" set to
+    the response code and "headers" and a body part of whatever the request returned for a body).
+
+    The final value returned from the endpoint is the encrypted bencoded bytes, and these encrypted
+    bytes are returned directly to the client (i.e. no base64 encoding applied, unlike v3 requests).
+    """  # noqa: E501
+
+    try:
+        if not (body.startswith(b'l') and body.endswith(b'e')):
+            raise RuntimeError("Invalid onion request body: expected bencoded list")
+
+        belems = memoryview(body)[1:-1]
+
+        # Metadata json; this element is always required:
+        meta, belems = utils.bencode_consume_string(belems)
+
+        meta = json.loads(meta.tobytes())
+
+        # Then we can have a second optional string containing the body:
+        if len(belems) > 1:
+            subreq_body, belems = utils.bencode_consume_string(belems)
+            if len(belems):
+                raise RuntimeError("Invalid v4 onion request: found more than 2 parts")
+        else:
+            subreq_body = b''
+
+        method, endpoint = meta['method'], meta['endpoint']
+        if not endpoint.startswith('/'):
+            raise RuntimeError("Invalid v4 onion request: endpoint must start with /")
+
+        response, headers = make_subrequest(
+            method,
+            endpoint,
+            headers=meta.get('headers', {}),
+            body=subreq_body,
+            user_reauth=True,  # Because onion requests have auth headers on the *inside*
+        )
+
+        data = response.get_data()
+        app.logger.debug(
+            f"Onion sub-request for {endpoint} returned {response.status_code}, {len(data)} bytes"
+        )
+
+        meta = {'code': response.status_code, 'headers': headers}
+
+    except Exception as e:
+        app.logger.warning("Invalid v4 onion request: {}".format(e))
+        meta = {'code': http.BAD_REQUEST, 'headers': {'content-type': 'text/plain; charset=utf-8'}}
+        data = b'Invalid v4 onion request'
+
+    meta = json.dumps(meta).encode()
+    return b''.join(
+        (b'l', str(len(meta)).encode(), b':', meta, str(len(data)).encode(), b':', data, b'e')
+    )
+
+
+def decrypt_onionreq():
+    try:
+        return crypto.parse_junk(request.data)
+    except Exception as e:
+        app.logger.warning("Failed to decrypt onion request: {}".format(e))
+    abort(http.BAD_REQUEST)
+
+
 @onion_request.post("/oxen/v3/lsrpc")
 @onion_request.post("/loki/v3/lsrpc")
-def handle_onion_request():
+def handle_v3_onion_request():
     """
-    Parse an onion request, handle it as a subrequest, then encrypt the subrequest result and send
-    it back to the requestor.
+    Parse an onion request, handle it as a subrequest, then throw away the subrequest headers,
+    replace the subrequest body with a json string, encrypt the final result and then pointlessly
+    base64 encodes the body before sending it back to the requestor.
+
+    Deprecated in favour of /v4/.
     """
 
+    junk = decrypt_onionreq()
+    return utils.encode_base64(junk.transformReply(handle_v3_onionreq_plaintext(junk.payload)))
+
+
+@onion_request.post("/oxen/v4/lsrpc")
+def handle_v4_onion_request():
+    """
+    Parse a v4 onion request.  See handle_v4_onionreq_plaintext().
+    """
+
+    # Some less-than-ideal decisions in the onion request protocol design means that we are stuck
+    # dealing with parsing the request body here in the internal format that is meant for storage
+    # server, but the *last* hop's decrypted, encoded data has to get shared by us (and is passed on
+    # to us in its raw, encoded form).  It looks like this:
+    #
+    # [N][blob][json]
+    #
+    # where N is the size of blob (4 bytes, little endian), and json contains *both* the elements
+    # that were meant for the last hop (like our host/port/protocol) *and* the elements that *we*
+    # need to decrypt blob (specifically: "ephemeral_key" and, optionally, "enc_type" [which can be
+    # used to use xchacha20-poly1305 encryption instead of AES-GCM]).
+    #
+    # The parse_junk here takes care of decoding and decrypting this according to the fields *meant
+    # for us* in the json (which include things like the encryption type and ephemeral key):
     try:
         junk = crypto.parse_junk(request.data)
     except RuntimeError as e:
         app.logger.warning("Failed to decrypt onion request: {}".format(e))
-        abort(http.INTERNAL_SERVER_ERROR)
+        abort(http.BAD_REQUEST)
 
-    response = handle_onionreq_plaintext(junk.payload)
-    return utils.encode_base64(junk.transformReply(response))
+    # On the way back out we re-encrypt via the junk parser (which uses the ephemeral key and
+    # enc_type that were specified in the outer request).  We then return that encrypted binary
+    # payload as-is back to the client which bounces its way through the SN path back to the client.
+    response = handle_v4_onionreq_plaintext(junk.payload)
+    return junk.transformReply(response)

--- a/sogs/routes/subrequest.py
+++ b/sogs/routes/subrequest.py
@@ -13,12 +13,13 @@ def make_subrequest(
     *,
     headers={},
     content_type: Optional[str] = None,
-    body: Optional[bytes] = None,
+    body: Optional[Union[bytes, memoryview]] = None,
     json: Optional[Union[dict, list]] = None,
     user_reauth: bool = False,
 ):
     """
-    Makes a subrequest from the given parameters, returns the response object.
+    Makes a subrequest from the given parameters, returns the response object and a dict of
+    lower-case response headers keys to header values.
 
     Parameters:
     method - the HTTP method, e.g. GET or POST
@@ -88,7 +89,12 @@ def make_subrequest(
             app.logger.warning(
                 f"Sub-request for {method} {path} returned status {response.status_code}"
             )
-        return response
+        return response, {
+            k.lower(): v
+            for k, v in response.get_wsgi_headers(subreq_env)
+            if k.lower() != 'content-length'
+        }
+
     except Exception:
         app.logger.warning(f"Sub-request for {method} {path} failed: {traceback.format_exc()}")
         raise

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -311,27 +311,27 @@ def test_auth_batch(client, db):
     expected = [
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
             'body': {'user': {'uid': 1, 'session_id': '05' + A.encode().hex()}, 'foo': 'bar'},
         },
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
             'body': {'user': {'uid': 1, 'session_id': '05' + A.encode().hex()}},
         },
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
             'body': {'user': {'uid': 1, 'session_id': '05' + A.encode().hex()}},
         },
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
             'body': {'user': {'uid': 1, 'session_id': '05' + A.encode().hex()}},
         },
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
             'body': {
                 'user': {'uid': 1, 'session_id': '05' + A.encode().hex()},
                 'body': ['hi', 'world'],
@@ -339,7 +339,7 @@ def test_auth_batch(client, db):
         },
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
             'body': {
                 'user': {'uid': 1, 'session_id': '05' + A.encode().hex()},
                 'body': {"it's": "you", "main screen": ["turn", "on"]},
@@ -477,19 +477,27 @@ def test_auth_legacy(client, db, admin, user, room):
     assert r.json == [
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
             'body': {'status_code': 200, 'banned_members': sorted([user.session_id, S2])},
         },
-        {'code': 200, 'content-type': 'application/json', 'body': {'status_code': 200}},
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
+            'body': {'status_code': 200},
+        },
+        {
+            'code': 200,
+            'headers': {'content-type': 'application/json'},
             'body': {'status_code': 200, 'banned_members': [S2]},
         },
-        {'code': 200, 'content-type': 'application/json', 'body': {'status_code': 200}},
         {
             'code': 200,
-            'content-type': 'application/json',
+            'headers': {'content-type': 'application/json'},
+            'body': {'status_code': 200},
+        },
+        {
+            'code': 200,
+            'headers': {'content-type': 'application/json'},
             'body': {'status_code': 200, 'banned_members': []},
         },
     ]

--- a/tests/test_onion_requests.py
+++ b/tests/test_onion_requests.py
@@ -1,0 +1,289 @@
+from sogs.web import app
+from sogs import crypto
+from sogs.hashing import blake2b
+from sogs import utils
+from nacl.bindings import (
+    crypto_scalarmult,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+)
+from Cryptodome.Cipher import AES
+import nacl.utils
+import struct
+import json
+import auth
+
+from nacl.public import PrivateKey
+
+# ephemeral X25519 keypair for use in tests
+a = PrivateKey(bytes.fromhex('ec32fb5766cf52b1b5d7b0bff08e29f5c0c58ca19beaf6a5c7d3dd8ac7ced963'))
+A = a.public_key
+assert A.encode().hex() == 'd79a50b82ba8ca665f854382b42ba159efd16eef87409e97a8d07395b9492928'
+
+# For xchacha20 with use the libsodium recommended shared key of H(aB || A || B), where H(.) is
+# 32-byte Blake2B
+shared_xchacha20_key = blake2b(
+    (
+        crypto_scalarmult(a.encode(), crypto.server_pubkey_bytes),
+        A.encode(),
+        crypto.server_pubkey_bytes,
+    )
+)
+
+# AES-GCM onion requests were implemented using the somewhat weaker shared key of just aB:
+shared_aes_key = crypto_scalarmult(a.encode(), crypto.server_pubkey_bytes)
+
+
+def build_payload(inner_json, inner_body=None, *, v, enc_type, outer_json_extra={}):
+    """Encrypt and encode a payload for sogs"""
+
+    if not isinstance(inner_json, bytes):
+        inner_json = json.dumps(inner_json).encode()
+
+    if v == 3:
+        assert inner_body is None
+        inner_data = inner_json
+    elif v == 4:
+        inner_data = b''.join(
+            (
+                b'l',
+                str(len(inner_json)).encode(),
+                b':',
+                inner_json,
+                *(() if inner_body is None else (str(len(inner_body)).encode(), b':', inner_body)),
+                b'e',
+            )
+        )
+    else:
+        raise RuntimeError(f"invalid payload v{v}")
+
+    inner_enc = ()
+    if enc_type in ("xchacha20", "xchacha20-poly1305"):
+        # For xchacha20 we stick the nonce to the beginning of the encrypted blob
+        nonce = nacl.utils.random(24)
+        inner_enc = (
+            nonce,
+            crypto_aead_xchacha20poly1305_ietf_encrypt(
+                inner_data, aad=None, nonce=nonce, key=shared_xchacha20_key
+            ),
+        )
+    elif enc_type in ("aes-gcm", "gcm"):
+        # For aes-gcm we stick the iv on the beginning of the encrypted blob and the mac tag on the
+        # end of it
+        iv = nacl.utils.random(12)
+        cipher = AES.new(shared_aes_key, AES.MODE_GCM, iv)
+        enc, mac = cipher.encrypt_and_digest(inner_data)
+        inner_enc = (iv, enc, mac)
+    else:
+        raise ValueError(f"Invalid enc_type: {enc_type}")
+
+    # The outer request is in storage server onion request format:
+    # [N][junk]{json}
+    # where we load the fields for the last hop *and* the fields for sogs into the json.
+    outer_json = {
+        "host": "localhost",
+        "port": 80,
+        "protocol": "http",
+        "target": f"/oxen/v{v}/lsrpc",
+        "ephemeral_key": A.encode().hex(),
+        "enc_type": enc_type,
+        **outer_json_extra,
+    }
+    return b''.join(
+        (
+            struct.pack('<i', sum(len(x) for x in inner_enc)),
+            *inner_enc,
+            json.dumps(outer_json).encode(),
+        )
+    )
+
+
+def decrypt_reply(data, *, v, enc_type):
+    """
+    Parses a reply; returns the json metadata and the body.  Note for v3 that there is only json;
+    body will always be None.
+    """
+    if v == 3:
+        data = utils.decode_base64(data)
+
+    if enc_type in ("xchacha20", "xchacha20-poly1305"):
+        assert len(data) > 24
+        nonce, enc = data[:24], data[24:]
+        data = crypto_aead_xchacha20poly1305_ietf_decrypt(
+            enc, aad=None, nonce=nonce, key=shared_xchacha20_key
+        )
+    elif enc_type in ("aes-gcm", "gcm"):
+        assert len(data) > 28
+        iv, enc, mac = data[:12], data[12:-16], data[-16:]
+        cipher = AES.new(shared_aes_key, AES.MODE_GCM, iv)
+        data = cipher.decrypt_and_verify(enc, mac)
+    else:
+        raise ValueError(f"Invalid enc_type: {enc_type}")
+
+    body = None
+
+    if v == 4:
+        assert (data[:1], data[-1:]) == (b'l', b'e')
+        data = memoryview(data)[1:-1]
+        json_data, data = utils.bencode_consume_string(data)
+        json_ = json.loads(json_data.tobytes())
+        if data:
+            body, data = utils.bencode_consume_string(data)
+            assert len(data) == 0
+            body = body.tobytes()
+    elif v == 3:
+        json_ = json.loads(data)
+
+    return json_, body
+
+
+def test_v3(room, client):
+
+    # Construct an onion request for /room/test-room
+    req = {'method': 'GET', 'endpoint': '/room/test-room'}
+    data = build_payload(req, v=3, enc_type="xchacha20")
+
+    r = client.post("/loki/v3/lsrpc", data=data)
+
+    assert r.status_code == 200
+
+    room_info = decrypt_reply(r.data, v=3, enc_type="xchacha20")[0]
+
+    assert room_info['description'] == 'Test suite testing room'
+    assert 'moderator' not in room_info
+
+
+def test_v3_authenticated(room, mod, client):
+
+    # Construct an onion request for /room/test-room
+    req = {'method': 'GET', 'endpoint': '/room/test-room'}
+    req['headers'] = auth.x_sogs(
+        mod.privkey, mod.privkey.public_key, crypto.server_pubkey, req['method'], req['endpoint']
+    )
+    data = build_payload(req, v=3, enc_type="xchacha20")
+
+    r = client.post("/loki/v3/lsrpc", data=data)
+
+    assert r.status_code == 200
+
+    room_info = decrypt_reply(r.data, v=3, enc_type="xchacha20")[0]
+
+    assert room_info['description'] == 'Test suite testing room'
+    assert 'moderator' in room_info and room_info['moderator']
+
+
+def test_v4(room, client):
+    req = {'method': 'GET', 'endpoint': '/room/test-room'}
+    data = build_payload(req, v=4, enc_type="xchacha20")
+
+    r = client.post("/oxen/v4/lsrpc", data=data)
+
+    assert r.status_code == 200
+
+    info, body = decrypt_reply(r.data, v=4, enc_type="xchacha20")
+
+    assert info == {'code': 200, 'headers': {'content-type': 'application/json'}}
+
+    room_info = json.loads(body)
+    assert room_info['description'] == 'Test suite testing room'
+    assert 'moderator' not in room_info
+
+
+def test_v4_authenticated(room, mod, client):
+    req = {'method': 'GET', 'endpoint': '/room/test-room'}
+    req['headers'] = auth.x_sogs(
+        mod.privkey, mod.privkey.public_key, crypto.server_pubkey, req['method'], req['endpoint']
+    )
+    data = build_payload(req, v=4, enc_type="xchacha20")
+
+    r = client.post("/oxen/v4/lsrpc", data=data)
+
+    assert r.status_code == 200
+
+    info, body = decrypt_reply(r.data, v=4, enc_type="xchacha20")
+
+    assert info == {'code': 200, 'headers': {'content-type': 'application/json'}}
+
+    room_info = json.loads(body)
+    assert room_info['description'] == 'Test suite testing room'
+    assert 'moderator' in room_info and room_info['moderator']
+
+
+@app.post("/test_v4_post_body")
+def v4_post_body():
+    from flask import request, jsonify, Response
+
+    if request.json is not None:
+        return jsonify({"json": request.json})
+    print(f"rd: {request.data}")
+    return Response(
+        f"not json ({request.content_type}): {request.data.decode()}".encode(),
+        mimetype='text/plain',
+    )
+
+
+def test_v4_post_body(room, user, client):
+    req = {'method': 'POST', 'endpoint': '/test_v4_post_body'}
+    content = b'test data'
+    req['headers'] = auth.x_sogs(
+        user.privkey,
+        user.privkey.public_key,
+        crypto.server_pubkey,
+        req['method'],
+        req['endpoint'],
+        body=content,
+    )
+    req['headers']['content-type'] = 'text/plain'
+
+    data = build_payload(req, content, v=4, enc_type="xchacha20")
+
+    r = client.post("/oxen/v4/lsrpc", data=data)
+
+    assert r.status_code == 200
+
+    info, body = decrypt_reply(r.data, v=4, enc_type="xchacha20")
+
+    assert info == {'code': 200, 'headers': {'content-type': 'text/plain; charset=utf-8'}}
+    assert body == b'not json (text/plain): test data'
+
+    # Now try with json:
+    test_json = {"test": ["json", None], "1": 23}
+    content = json.dumps(test_json).encode()
+    req['headers'] = auth.x_sogs(
+        user.privkey,
+        user.privkey.public_key,
+        crypto.server_pubkey,
+        req['method'],
+        req['endpoint'],
+        body=content,
+    )
+    req['headers']['content-type'] = 'application/json'
+    data = build_payload(req, content, v=4, enc_type="xchacha20")
+    r = client.post("/oxen/v4/lsrpc", data=data)
+
+    assert r.status_code == 200
+
+    info, body = decrypt_reply(r.data, v=4, enc_type="xchacha20")
+
+    assert info == {'code': 200, 'headers': {'content-type': 'application/json'}}
+    assert json.loads(body) == {"json": test_json}
+
+    # Now try with json, but with content-type set to something else (this should avoid the json
+    req['headers'] = auth.x_sogs(
+        user.privkey,
+        user.privkey.public_key,
+        crypto.server_pubkey,
+        req['method'],
+        req['endpoint'],
+        body=content,
+    )
+    req['headers']['content-type'] = 'x-omg/all-your-base'
+    data = build_payload(req, content, v=4, enc_type="xchacha20")
+    r = client.post("/oxen/v4/lsrpc", data=data)
+
+    assert r.status_code == 200
+
+    info, body = decrypt_reply(r.data, v=4, enc_type="xchacha20")
+
+    assert info == {'code': 200, 'headers': {'content-type': 'text/plain; charset=utf-8'}}
+    assert body == b'not json (x-omg/all-your-base): ' + content

--- a/tests/test_routes_general.py
+++ b/tests/test_routes_general.py
@@ -26,7 +26,7 @@ def test_capabilities(client):
 
 
 def expected_result(code, body, ct="application/json"):
-    return {"code": code, "content-type": ct, "body": body}
+    return {"code": code, "headers": {"content-type": ct}, "body": body}
 
 
 def batch_data():


### PR DESCRIPTION
Adds a new v4 SOGS onion request that allows efficiently passing binary data.

This solves six glaring issues with v3 onion requests:
1. it is impossible to pass binary data through an onion request because onion requests are always json, and thus v3-reachable endpoints have to accept data as base64, which means a 33% increase in data size.
2. for endpoints where we want to be able to pass binary data and *aren't* going through onion requests (e.g. from an oxenmq bot) we have to duplicate the endpoint to have a second version that takes it without json encoding overhead, or else incur the overhead.
3. v3 requests always return json, and thus have the same amplification of data (due to a requirement to have to slam binary data into json) on the return path to the client.
4. v3 requests always apply *another* round of base64 encoding after the encryption for the client, which means there is a 78% amplification of any binary data being returned to a client.
5. The base64 willy nilly everywhere makes onion requests slower: because, in either direction, we have to fully transmit the data from one hop to the next before we can begin transmitting to the next one, this means that the amplification adds latency when uploading/downloading large attachments.
6. v3 requests completely discard any returned headers which mean, for instance, that serving a file with a proper Content-Disposition header specifying the filename is impossible.  (Instead, you'd have to slam everything into the json return rather than use the standard headers).

These are solved by:
1. data is passed in two parts: a json request metadata, and a binary body.
2. no duplication request handlers are needed because we don't need to avoid inefficient extra encoding
3. endpoints accessed by v4 can return any content-type they like.  For attachments, for instance, we can return `application/octet-stream` bytes with no overhead.
4. v4 requests do not base64 encode anything; they return encrypted data as binary.
5. No data amplification means no added latency
6. v4 responses include response headers (like content-type) 

## Request encoding

The quick overview of how requests get encoded with v4 is:

v4 allows more generic requests by taking the data in two parts:

- metadata json describing the request
- the request data

The metadata is effectively the same as the v3 request body, except that it does not contain a `body` element.

The request data (which is only included in POST/PUT requests) is binary data and can be anything.  Unlike v3, this means the request needs to include a Content-Type header, which typically not specified in v3 (since it could only ever be application/json).

Finally these parts are glued together using simple bencoding, chosen to only be a list of strings that is simple enough that it can be easily encoded/decoded by hand without requiring a full bencode library (though of course a full bencode parser/producer will work fine).  The format of the bencode subset used for v4 onion requests is this:

- `N:data` is a binary string, where `N` is a decimal number.  For example `11:hello world` encodes the byte string `hello world`.
- `l` begins a list; the list is followed by 1 or 2 binary strings; then is terminated with an `e`.

so, for example, a v4 onion request to `GET` the `/room/test-room` endpoint would look like this:
```
l45:{"method":"GET","endpoint":"/room/test-room"}e
```
and a POST request for `/room/test-room/pin/123` with a json body of `{}` would look like:
```
l100:{"method":"POST","endpoint":"/room/test-room/pin/123","headers":{"Content-Type":"application/json"}}2:{}e
```

## Response encoding

Response encoding is nearly identical to the request encoding: the first part is json containing the response metadata, and the second part is the request body.  (Unlike requests, there are always exactly 2 parts instead of 1-or-2 parts).

The json part is an object with fields `"code"` containing the HTTP response code and `"headers"` containing HTTP headers (with always-lower-case header names).  For instance:

```json
{"code":200,"headers":{"content-type":"application/json"}}
```
and
```json
{"id":789}
```
encoded as:
```
l58:{"code":200,"headers":{"content-type":"application/json"}}10:{"id":789}e
```
or, for an attachment download (where the response would not be json):
```json
{"code":200,"headers":{"content-type":"application/octet-stream","content-disposition":"attachment;filename*=UTF-8''myfile.txt"}}
```
with body `hello world`:
```
l129:{"code":200,"headers":{"content-type":"application/octet-stream","content-disposition":"attachment;filename*=UTF-8''myfile.txt"}}11:hello worlde
```