### PR TITLE
Ensure nacl 1.4.0+; add tests for small subgroups

### DIFF
--- a/sogs/crypto.py
+++ b/sogs/crypto.py
@@ -2,6 +2,7 @@ from . import config
 
 import os
 
+import nacl
 from nacl.public import PrivateKey
 from nacl.signing import SigningKey, VerifyKey
 from nacl.encoding import Base64Encoder, HexEncoder
@@ -20,6 +21,10 @@ import hmac
 import functools
 
 import pyonionreq
+
+if [int(v) for v in nacl.__version__.split('.')] < [1, 4]:
+    raise ImportError("SOGS requires nacl v1.4.0+")
+
 
 # generate seed as needed
 if not os.path.exists(config.KEY_FILE):


### PR DESCRIPTION
Several of the sodium bindings we use weren't added until nacl 1.4.0, so fail if we don't have that.

(I've also pushed Debian's 1.5.0-2 python3-nacl package from sid to the focal oxen repo, which works just fine on focal).