### PR TITLE
Fix bug that made key_convert always overwrite

### DIFF
--- a/sogs/key_convert/__main__.py
+++ b/sogs/key_convert/__main__.py
@@ -38,6 +38,7 @@ if not args.overwrite and os.path.exists(args.out):
         f"Error: {args.out} already exists, not overwriting it without --overwrite flag!",
         file=sys.stderr,
     )
+    sys.exit(1)
 
 key = c.load_privatekey(c.FILETYPE_PEM, pkey_pem).to_cryptography_key()
 pubkey_hex = key.public_key().public_bytes(encoding=s.Encoding.Raw, format=s.PublicFormat.Raw).hex()


### PR DESCRIPTION
Fixes a bug in the key convert script.  In practice this doesn't matter all that much as the only place this is used is in the deb (which only calls it if the key doesn't exist), but should still be fixed.