### PR TITLE
User permission blinding migration

### DIFF
--- a/contrib/blinding.py
+++ b/contrib/blinding.py
@@ -1,5 +1,5 @@
 from nacl.signing import SigningKey, VerifyKey
-import nacl.bindings as salt
+import nacl.bindings as sodium
 from nacl.utils import random
 import nacl.hash
 from hashlib import blake2b
@@ -16,24 +16,26 @@ for i in range(trials):
 
     # This seems a bit weird, but: sodium's sk-to-curve uses the same private key scalar (a) for
     # both curves, so getting `a` for the curve25519 implicitly gives us the ed25519 `a` as well.
-    a = salt.crypto_sign_ed25519_sk_to_curve25519(s.encode() + A)
+    a = sodium.crypto_sign_ed25519_sk_to_curve25519(s.encode() + A)
 
     A_xpk = s.to_curve25519_private_key().public_key.encode()  # session id is 05 + this
 
-    assert salt.crypto_scalarmult_ed25519_base_noclamp(a) == A
-    assert salt.crypto_scalarmult_base(a) == A_xpk
-    assert salt.crypto_core_ed25519_is_valid_point(A)
+    assert sodium.crypto_scalarmult_ed25519_base_noclamp(a) == A
+    assert sodium.crypto_scalarmult_base(a) == A_xpk
+    assert sodium.crypto_core_ed25519_is_valid_point(A)
 
     server_pubkey = random(32)
-    k = salt.crypto_core_ed25519_scalar_reduce(nacl.hash.generichash(server_pubkey, digest_size=64))
+    k = sodium.crypto_core_ed25519_scalar_reduce(
+        nacl.hash.generichash(server_pubkey, digest_size=64)
+    )
 
-    ka = salt.crypto_core_ed25519_scalar_mul(k, a)
+    ka = sodium.crypto_core_ed25519_scalar_mul(k, a)
     # kA will be my blinded pubkey visible from my posts, with '15' prepended, and is an *Ed*
     # pubkey, not an X pubkey.
-    kA = salt.crypto_scalarmult_ed25519_noclamp(k, A)
+    kA = sodium.crypto_scalarmult_ed25519_noclamp(k, A)
 
-    assert salt.crypto_scalarmult_ed25519_base_noclamp(ka) == kA
-    assert salt.crypto_core_ed25519_is_valid_point(kA)
+    assert sodium.crypto_scalarmult_ed25519_base_noclamp(ka) == kA
+    assert sodium.crypto_core_ed25519_is_valid_point(kA)
 
     #############################
     # Signing (e.g. for X-SOGS-*) with a blinded keypair ka/kA
@@ -45,13 +47,17 @@ for i in range(trials):
     # which gives us a bog standard Ed25519 that can be verified using the kA pubkey with standard
     # verification code.
     message_to_sign = b'omg happy days'
-    H_rh = salt.crypto_hash_sha512(s.encode())[32:]
-    r = salt.crypto_core_ed25519_scalar_reduce(salt.crypto_hash_sha512(H_rh + kA + message_to_sign))
-    sig_R = salt.crypto_scalarmult_ed25519_base_noclamp(r)
-    HRAM = salt.crypto_core_ed25519_scalar_reduce(
-        salt.crypto_hash_sha512(sig_R + kA + message_to_sign)
+    H_rh = sodium.crypto_hash_sha512(s.encode())[32:]
+    r = sodium.crypto_core_ed25519_scalar_reduce(
+        sodium.crypto_hash_sha512(H_rh + kA + message_to_sign)
     )
-    sig_s = salt.crypto_core_ed25519_scalar_add(r, salt.crypto_core_ed25519_scalar_mul(HRAM, ka))
+    sig_R = sodium.crypto_scalarmult_ed25519_base_noclamp(r)
+    HRAM = sodium.crypto_core_ed25519_scalar_reduce(
+        sodium.crypto_hash_sha512(sig_R + kA + message_to_sign)
+    )
+    sig_s = sodium.crypto_core_ed25519_scalar_add(
+        r, sodium.crypto_core_ed25519_scalar_mul(HRAM, ka)
+    )
     full_sig = sig_R + sig_s
 
     assert VerifyKey(kA).verify(message_to_sign, full_sig)
@@ -62,29 +68,29 @@ for i in range(trials):
     # Our user A above wants to send a SOGS DM to another user B:
     s2 = SigningKey.generate()
     B = s2.verify_key.encode()
-    b = salt.crypto_sign_ed25519_sk_to_curve25519(s2.encode() + B)
+    b = sodium.crypto_sign_ed25519_sk_to_curve25519(s2.encode() + B)
 
     # with blinded keys:
-    kb = salt.crypto_core_ed25519_scalar_mul(k, b)
-    kB = salt.crypto_scalarmult_ed25519_noclamp(k, B)
+    kb = sodium.crypto_core_ed25519_scalar_mul(k, b)
+    kB = sodium.crypto_scalarmult_ed25519_noclamp(k, B)
 
     B_xpk = s2.to_curve25519_private_key().public_key.encode()
 
-    assert salt.crypto_scalarmult_ed25519_base_noclamp(kb) == kB
-    assert salt.crypto_core_ed25519_is_valid_point(kB)
+    assert sodium.crypto_scalarmult_ed25519_base_noclamp(kb) == kB
+    assert sodium.crypto_core_ed25519_is_valid_point(kB)
 
     #############################
     # Finding friends:
 
     # For example (in reality this would come directly from the known session id):
-    friend_xpk = salt.crypto_sign_ed25519_pk_to_curve25519(A)
+    friend_xpk = sodium.crypto_sign_ed25519_pk_to_curve25519(A)
 
     # From the session id (ignoring 05 prefix) we have two possible ed25519 pubkeys; the first is
     # the positive (which is what Signal's XEd25519 conversion always uses):
     pk1 = xed25519.pubkey(friend_xpk)
 
     # Blind it:
-    pk1 = salt.crypto_scalarmult_ed25519_noclamp(k, pk1)
+    pk1 = sodium.crypto_scalarmult_ed25519_noclamp(k, pk1)
 
     # For the negative, what we're going to get out of the above is simply the negative of pk1, so
     # flip the sign bit to get pk2:
@@ -102,7 +108,7 @@ for i in range(trials):
     # around gives the same result as the shortcut:
     pk2_alt = xed25519.pubkey(friend_xpk)
     pk2_alt = pk2_alt[0:31] + bytes([pk2_alt[31] | 0b1000_0000])
-    pk2_alt = salt.crypto_scalarmult_ed25519_noclamp(k, pk2_alt)
+    pk2_alt = sodium.crypto_scalarmult_ed25519_noclamp(k, pk2_alt)
     assert pk2 == pk2_alt
 
     # Now, if this is really my friend, his blinded key will equal one of these blinded keys:
@@ -128,7 +134,7 @@ for i in range(trials):
     # BLAKE2b(b kA || kA || kB)
     #
     enc_key = blake2b(
-        salt.crypto_scalarmult_ed25519_noclamp(a, kB) + kA + kB, digest_size=32
+        sodium.crypto_scalarmult_ed25519_noclamp(a, kB) + kA + kB, digest_size=32
     ).digest()
 
     # Inner data: msg || A   (i.e. the sender's ed25519 master pubkey, *not* kA blinded pubkey)
@@ -136,7 +142,7 @@ for i in range(trials):
 
     # Encrypt using xchacha20-poly1305
     nonce = random(24)
-    ciphertext = salt.crypto_aead_xchacha20poly1305_ietf_encrypt(
+    ciphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
         plaintext, aad=None, nonce=nonce, key=enc_key
     )
 
@@ -151,7 +157,7 @@ for i in range(trials):
 
     # Calculate the shared encryption key (see above)
     dec_key = blake2b(
-        salt.crypto_scalarmult_ed25519_noclamp(b, kA) + kA + kB, digest_size=32
+        sodium.crypto_scalarmult_ed25519_noclamp(b, kA) + kA + kB, digest_size=32
     ).digest()
 
     assert enc_key == dec_key
@@ -162,7 +168,9 @@ for i in range(trials):
     assert v == 0x00  # Make sure our encryption version is okay
 
     # Decrypt
-    plaintext = salt.crypto_aead_xchacha20poly1305_ietf_decrypt(ct, aad=None, nonce=nc, key=dec_key)
+    plaintext = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(
+        ct, aad=None, nonce=nc, key=dec_key
+    )
 
     assert len(plaintext) > 32
 
@@ -170,11 +178,11 @@ for i in range(trials):
     message, sender_edpk = plaintext[:-32], plaintext[-32:]
 
     # Verify that the inner sender_edpk (A) yields the same outer kA we got with the message
-    assert kA == salt.crypto_scalarmult_ed25519_noclamp(k, sender_edpk)
+    assert kA == sodium.crypto_scalarmult_ed25519_noclamp(k, sender_edpk)
 
     message = message.decode()  # utf-8 bytes back to str
 
-    sender_session_id = '05' + salt.crypto_sign_ed25519_pk_to_curve25519(sender_edpk).hex()
+    sender_session_id = '05' + sodium.crypto_sign_ed25519_pk_to_curve25519(sender_edpk).hex()
 
     assert message == msg
     assert sender_edpk == A

--- a/contrib/pg-import.py
+++ b/contrib/pg-import.py
@@ -65,6 +65,7 @@ TABLES = [
     "user_ban_futures",
     "user_request_nonces",
     "inbox",
+    "needs_blinding",
 ]
 
 with pgsql.transaction():

--- a/sogs/__main__.py
+++ b/sogs/__main__.py
@@ -265,7 +265,7 @@ elif args.add_moderators:
 
     if args.rooms == ['+']:
         for sid in args.add_moderators:
-            u = User(session_id=sid)
+            u = User(session_id=sid, try_blinding=True)
             u.set_moderator(admin=args.admin, visible=args.visible, added_by=sysadmin)
             print(
                 "Added {} as {} global {}".format(
@@ -284,7 +284,7 @@ elif args.add_moderators:
                 print(f"No such room: '{nsr.token}'", file=sys.stderr)
 
         for sid in args.add_moderators:
-            u = User(session_id=sid)
+            u = User(session_id=sid, try_blinding=True)
             for room in rooms:
                 room.set_moderator(u, admin=args.admin, visible=not args.hidden, added_by=sysadmin)
                 print(
@@ -315,7 +315,7 @@ elif args.delete_moderators:
 
     if args.rooms == ['+']:
         for sid in args.delete_moderators:
-            u = User(session_id=sid)
+            u = User(session_id=sid, try_blinding=True)
             was_admin = u.global_admin
             if not u.global_admin and not u.global_moderator:
                 print(f"{u.session_id} was not a global moderator")
@@ -332,7 +332,7 @@ elif args.delete_moderators:
                 print(f"No such room: '{nsr.token}'", file=sys.stderr)
 
         for sid in args.delete_moderators:
-            u = User(session_id=sid)
+            u = User(session_id=sid, try_blinding=True)
             for room in rooms:
                 room.remove_moderator(u, removed_by=sysadmin)
                 print(f"Removed {u.session_id} as moderator/admin of {room.name} ({room.token})")

--- a/sogs/migrations/new_tables.py
+++ b/sogs/migrations/new_tables.py
@@ -54,6 +54,22 @@ CREATE TABLE inbox (
 CREATE INDEX inbox_recipient ON inbox(recipient);
 """,
     },
+    'needs_blinding': {
+        'sqlite': [
+            """
+CREATE TABLE needs_blinding (
+    blinded_abs TEXT NOT NULL PRIMARY KEY,
+    "user" BIGINT NOT NULL UNIQUE REFERENCES users ON DELETE CASCADE
+)
+"""
+        ],
+        'pgsql': """
+CREATE TABLE needs_blinding (
+    blinded_abs TEXT NOT NULL PRIMARY KEY,
+    "user" BIGINT NOT NULL UNIQUE REFERENCES users ON DELETE CASCADE
+)
+""",
+    },
 }
 
 

--- a/sogs/model/user.py
+++ b/sogs/model/user.py
@@ -36,7 +36,7 @@ class User:
         returning it.
         """
         self._touched = False
-        self._refresh(row=row, id=id, session_id=session_id)
+        self._refresh(row=row, id=id, session_id=session_id, autovivify=autovivify)
 
         if touch:
             self._touch()

--- a/sogs/routes/auth.py
+++ b/sogs/routes/auth.py
@@ -1,6 +1,6 @@
 from ..web import app
 from ..db import query
-from .. import crypto, http, utils
+from .. import config, crypto, http, utils
 from ..model.user import User
 from ..hashing import blake2b
 
@@ -247,8 +247,11 @@ def handle_http_auth():
     pk = VerifyKey(pk)
     if blinded_pk:
         session_id = '15' + pk.encode().hex()
+    elif config.REQUIRE_BLIND_KEYS:
+        abort_with_reason(
+            http.BAD_REQUEST, "Invalid authentication: this server requires the use of blinded ids"
+        )
     else:
-        # TODO: if "blinding required" config option is set then reject the request here
         try:
             session_id = '05' + pk.to_curve25519_public_key().encode().hex()
         except nacl.exceptions.RuntimeError:

--- a/sogs/routes/auth.py
+++ b/sogs/routes/auth.py
@@ -9,7 +9,7 @@ import time
 import nacl
 from nacl.signing import VerifyKey
 import nacl.exceptions
-import nacl.bindings as salt
+import nacl.bindings as sodium
 import sqlalchemy.exc
 from functools import wraps
 
@@ -238,7 +238,7 @@ def handle_http_auth():
     blinded_pk = pk[0] == 0x15
     pk = pk[1:]
 
-    if not salt.crypto_core_ed25519_is_valid_point(pk):
+    if not sodium.crypto_core_ed25519_is_valid_point(pk):
         abort_with_reason(
             http.BAD_REQUEST,
             "Invalid authentication: given X-SOGS-Pubkey is not a valid Ed25519 pubkey",

--- a/sogs/routes/users.py
+++ b/sogs/routes/users.py
@@ -169,7 +169,7 @@ def set_mod(sid):
     404 Not Found — if one or more of the given `rooms` tokens do not exist.
     """
 
-    user = User(session_id=sid)
+    user = User(session_id=sid, try_blinding=True)
 
     req = request.json
 
@@ -296,7 +296,7 @@ def ban_user(sid):
     404 Not Found — if one or more of the given `rooms` tokens do not exist.
     """
 
-    user = User(session_id=sid)
+    user = User(session_id=sid, try_blinding=True)
     req = request.json
     rooms, global_ban = extract_rooms_or_global(req, admin=False)
 
@@ -364,7 +364,7 @@ def unban_user(sid):
     404 Not Found — if one or more of the given `rooms` tokens do not exist.
     """
 
-    user = User(session_id=sid)
+    user = User(session_id=sid, try_blinding=True)
     rooms, global_ban = extract_rooms_or_global(request.json, admin=False)
 
     if rooms:

--- a/sogs/schema.pgsql
+++ b/sogs/schema.pgsql
@@ -172,6 +172,17 @@ FOR EACH ROW WHEN (NEW.admin AND NOT NEW.moderator)
 EXECUTE PROCEDURE trigger_user_admins_are_mods();
 
 
+-- This table tracks unblinded session ids in user_permission (and related) rows that need to be
+-- blinded, which will happen the first time the user authenticates with their blinded id (until
+-- they do, we can't know the actual sign bit of their blinded id).  It is populated at startup
+-- when blinding is first enabled, and is used both for the initial blinding transition and when
+-- ids are added by raw session ID (e.g. when adding a moderator by session id).
+CREATE TABLE needs_blinding (
+    blinded_abs TEXT NOT NULL PRIMARY KEY, -- the positive of the possible two blinded keys
+    "user" BIGINT NOT NULL UNIQUE REFERENCES users ON DELETE CASCADE
+);
+
+
 -- Effectively the same as `messages` except that it also includes the `session_id` from the users
 -- table of the user who posted it, and the session id of the whisper recipient (as `whisper_to`) if
 -- a directed whisper.

--- a/sogs/schema.sqlite
+++ b/sogs/schema.sqlite
@@ -151,6 +151,18 @@ BEGIN
 END;
 
 
+-- This table tracks unblinded session ids in user_permission (and related) rows that need to be
+-- blinded, which will happen the first time the user authenticates with their blinded id (until
+-- they do, we can't know the actual sign bit of their blinded id).  It is populated at startup
+-- when blinding is first enabled, and is used both for the initial blinding transition and when
+-- ids are added by raw session ID (e.g. when adding a moderator by session id).
+CREATE TABLE needs_blinding (
+    blinded_abs TEXT NOT NULL PRIMARY KEY, -- the positive of the possible two blinded keys
+    "user" INTEGER NOT NULL UNIQUE REFERENCES users ON DELETE CASCADE
+);
+
+
+
 -- Effectively the same as `messages` except that it also includes the `session_id` from the users
 -- table of the user who posted it, and the session id of the whisper recipient (as `whisper_to`) if
 -- a directed whisper.

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -3,7 +3,7 @@ from nacl.public import PublicKey
 from typing import Optional
 import time
 from sogs.hashing import blake2b, sha512
-import nacl.bindings as salt
+import nacl.bindings as sodium
 from nacl.utils import random
 
 import sogs.utils
@@ -37,11 +37,11 @@ def x_sogs_raw(
 
     if blinded:
         a = s.to_curve25519_private_key().encode()
-        k = salt.crypto_core_ed25519_scalar_reduce(
+        k = sodium.crypto_core_ed25519_scalar_reduce(
             blake2b(sogs.crypto.server_pubkey_bytes, digest_size=64)
         )
-        ka = salt.crypto_core_ed25519_scalar_mul(k, a)
-        kA = salt.crypto_scalarmult_ed25519_base_noclamp(ka)
+        ka = sodium.crypto_core_ed25519_scalar_mul(k, a)
+        kA = sodium.crypto_scalarmult_ed25519_base_noclamp(ka)
         pubkey = '15' + kA.hex()
     else:
         pubkey = '00' + s.verify_key.encode().hex()
@@ -52,11 +52,11 @@ def x_sogs_raw(
 
     if blinded:
         H_rh = sha512(s.encode())[32:]
-        r = salt.crypto_core_ed25519_scalar_reduce(sha512([H_rh, kA, *to_sign]))
-        sig_R = salt.crypto_scalarmult_ed25519_base_noclamp(r)
-        HRAM = salt.crypto_core_ed25519_scalar_reduce(sha512([sig_R, kA, *to_sign]))
-        sig_s = salt.crypto_core_ed25519_scalar_add(
-            r, salt.crypto_core_ed25519_scalar_mul(HRAM, ka)
+        r = sodium.crypto_core_ed25519_scalar_reduce(sha512([H_rh, kA, *to_sign]))
+        sig_R = sodium.crypto_scalarmult_ed25519_base_noclamp(r)
+        HRAM = sodium.crypto_core_ed25519_scalar_reduce(sha512([sig_R, kA, *to_sign]))
+        sig_s = sodium.crypto_core_ed25519_scalar_add(
+            r, sodium.crypto_core_ed25519_scalar_mul(HRAM, ka)
         )
         sig = sig_R + sig_s
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ import sogs.utils
 
 import json
 from nacl.signing import SigningKey
-import nacl.bindings as salt
+import nacl.bindings as sodium
 
 
 @app.get("/auth_test/whoami")
@@ -507,15 +507,15 @@ def test_small_subgroups(client, db):
 
     assert A == a.verify_key.encode()
 
-    if hasattr(salt, 'crypto_core_ed25519_is_valid_point'):
-        assert salt.crypto_core_ed25519_is_valid_point(A)
+    if hasattr(sodium, 'crypto_core_ed25519_is_valid_point'):
+        assert sodium.crypto_core_ed25519_is_valid_point(A)
 
-    Abad = salt.crypto_core_ed25519_add(
+    Abad = sodium.crypto_core_ed25519_add(
         A, bytes.fromhex('0000000000000000000000000000000000000000000000000000000000000000')
     )
 
-    if hasattr(salt, 'crypto_core_ed25519_is_valid_point'):
-        assert not salt.crypto_core_ed25519_is_valid_point(Abad)
+    if hasattr(sodium, 'crypto_core_ed25519_is_valid_point'):
+        assert not sodium.crypto_core_ed25519_is_valid_point(Abad)
 
     headers['X-SOGS-Pubkey'] = '00' + Abad.hex()
 
@@ -528,12 +528,12 @@ def test_small_subgroups(client, db):
     assert headers['X-SOGS-Pubkey'].startswith('15')
     A = bytes.fromhex(headers['X-SOGS-Pubkey'][2:])
 
-    Abad = salt.crypto_core_ed25519_add(
+    Abad = sodium.crypto_core_ed25519_add(
         A, bytes.fromhex('c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a')
     )
 
-    if hasattr(salt, 'crypto_core_ed25519_is_valid_point'):
-        assert not salt.crypto_core_ed25519_is_valid_point(Abad)
+    if hasattr(sodium, 'crypto_core_ed25519_is_valid_point'):
+        assert not sodium.crypto_core_ed25519_is_valid_point(Abad)
 
     headers['X-SOGS-Pubkey'] = '15' + Abad.hex()
     r = client.get("/auth_test/whoami", headers=headers)

--- a/tests/test_blinding.py
+++ b/tests/test_blinding.py
@@ -1,0 +1,277 @@
+from sogs import crypto
+from sogs.model.room import Room
+from nacl.signing import SigningKey
+from sogs.hashing import blake2b
+from util import config_override
+import nacl.bindings as sodium
+import pytest
+import time
+
+from auth import x_sogs
+
+
+# For test reproducability use this fixed server pubkey for the blinding derivation tests (because
+# each test environment typically has its own, which completely changes the derived pubkeys).
+fake_server_pubkey_bytes = bytes.fromhex(
+    '6a32c7b491f4199dd1260a4cc60ae51c6bd71dad939cc521e738409f53f943be'
+)
+
+
+@pytest.mark.parametrize(
+    ["seed_hex", "blinded_id_exp"],
+    [
+        pytest.param(
+            "880adf5164a79bce71f7387fbc2cb2693c0bf0ab4cb42bf1edafddade7527a66",
+            "15cef185d46b60a548641bd8c5baa4b7cf90b7da8e883c0ac774c703d249086479",
+        ),
+        pytest.param(
+            "67416582e0700081604860d270bc986011fc5e62c53de908a9a5af2cb497c528",
+            "15f8fbeb20cdde5e0cc0ec84e0b3705ca6090c7b23e8132589970473a5592ba388",
+        ),
+        pytest.param(
+            "a5ad71709cfa315d147921e377186270367fd06926f4dbfe33f519dec6b016f7",
+            "15758e10dc51210d7a36ea6076e2aa84d9f87283bddb508364272dce0a7618f92a",
+        ),
+        pytest.param(
+            "c929a389a0dcf375ae8177891655b3835773e3a2d6d27490de8b8a160ca472f8",
+            "1515ad8f8c5e56b31078a4a5ae73938bd523b1c86ea36033d564759e4495fbb64d",
+        ),
+        pytest.param(
+            "0576076b8a82aae0fa1d0f00e97b538b43205f63759a972f26b851a55b60b5d0",
+            "15375a56d4cbf0538f4b326e54917fd1953e9e3dfe076eb8b35929a8d869a15c13",
+        ),
+        pytest.param(
+            "0a5db01db307ffd1bbe3cdd0d47c71e8837c60b38983d1df1b187301959095c9",
+            "151a821dd107ac68845f82085efb1f88d046a084a63f7fc381ec07a367e6bc5aac",
+        ),
+        pytest.param(
+            "d9b4ff572d4ebbcf26b07329f9029462f0606087d64e8932e698aa0a98231ce3",
+            "15a4acf4c814fd1bcf83ebbe42c276630a63e32365633cb57089544b3a60b5e4ac",
+        ),
+        pytest.param(
+            "dbcf64e7e6323ace8a75327119c13ef0b41e0efb94e594a6424ba41472987844",
+            "1503e60a1fbde2a930e11db0898220ceb41e5ea9161f61ff1dc7d83be3e9b96993",
+        ),
+        pytest.param(
+            "2e90f20775370121a2db8413a68bb41c3618e63c744c865d8b03ca2cb9d52e9e",
+            "150bfdf09d985453d70b07b779ac7de982c0b6190c19126df74e8ca3adbfb87fec",
+        ),
+        pytest.param(
+            "0b19b8b2f006f73810a86244697ac3feb3500af22f97434bf1e4bac575e95d2f",
+            "15c430f8cf5e3ca4a3d0fa79d75fe60b3dc21212b4467ddd01fc1173c738161628",
+        ),
+        pytest.param(
+            "32c58327a3856acb77ca0e97993100b4a14475b2d5cd3804213ae2d6f2515709",
+            "150fdb6a400ade0aa2d261999fc51aa0151201d30626b30ec94d3a06a927948523",
+        ),
+        pytest.param(
+            "f5c57e9949bbb87b3ae9fa374bc05b8e945c33141b7eb19c5125d17023120287",
+            "15cdda69401f8ca32c4760b025b8315967ce9f5c53d4b75239b26d8ff9db5852f8",
+        ),
+        pytest.param(
+            "3aacbfb5059e1df00d11ff5742f8a5b91cdb9fe163f38906d7dfaae29ad30c0c",
+            "152701bb6cf273f7c30a0b2bb3a4b027415aab3fdff5d44b7b50af269aaa46007d",
+        ),
+        pytest.param(
+            "cce2487f4f1a01a54811204e8c774e7380c080f5f40cda0ef395752ef96dd35c",
+            "15c92aa80e809a84d97323f911355d5015e916f3d5bebc297a17b4c44bad487ad6",
+        ),
+        pytest.param(
+            "a414c2990f36a115308f74bbcb56c4238135c0578abf8de0505b08e9c7b69134",
+            "150e51c490bc7c570310276b7fdaeb9e0e14ab4674ce8217df5418b621b52c5c31",
+        ),
+        pytest.param(
+            "cbf84283c5d4a906b81e7533005fdd832d9d3712e71d5ee8247e3d32c1e2e38c",
+            "157b0487fa9bc7449a167d66b56eb3e3fc628101d84a08f3f510f46de90de2e3a4",
+        ),
+        pytest.param(
+            "e75399dac3b5b3675874ba1708d1effc6ab9bbd5b0fac4cf78a3c2b36af9cfc5",
+            "15f277d3d6afbecc15c71d16c3f183e6dbb772b176f3c818265f4459aa649b9d80",
+        ),
+        pytest.param(
+            "6cef60808348898f17123eb4f47556f22ae0e7bd1988455da6d4b685ea0f93d0",
+            "152d766ba9a19fd108e8f397b7fddaad2473cf13192858b8fd28f641e6c817c7c1",
+        ),
+        pytest.param(
+            "9396176367912b4bc9b2fca427bf7fea97293ee9db75e521e31e4618e2da061c",
+            "15a2308a015da570bd749348991d4fee7b0ea5816f372a6c584581964680c9d46a",
+        ),
+        pytest.param(
+            "b9ac6f130f0ef218e1fbd9484b38ba3a0a8ec5657744732b0a4a9e7f6c80a62e",
+            "1513533ac53ea094b0c0e907046ffc2ade32122da069df503583bf89d6af01e127",
+        ),
+    ],
+)
+def test_blinded_key_derivation(seed_hex, blinded_id_exp):
+    """
+    Tests that we can successfully compute the blinded session id from the unblinded session id.
+
+    seed_hex - the ed25519 master key seed
+    blinded_id_exp - the expected blinded ed25519-based pubkey
+    """
+
+    s = SigningKey(bytes.fromhex(seed_hex))
+    # The following name is misleading name: this is an easy way to extract the private scalar
+    # (which happens to *also* be the private scalar when converting to curve, hence the name).
+    a = s.to_curve25519_private_key().encode()
+
+    k = sodium.crypto_core_ed25519_scalar_reduce(blake2b(fake_server_pubkey_bytes, digest_size=64))
+    ka = sodium.crypto_core_ed25519_scalar_mul(k, a)
+    kA = sodium.crypto_scalarmult_ed25519_base_noclamp(ka)
+
+    session_id = '05' + s.to_curve25519_private_key().public_key.encode().hex()
+    blinded_id = '15' + kA.hex()
+
+    assert blinded_id == blinded_id_exp
+
+    id_pos = crypto.compute_blinded_abs_id(session_id, k=k)
+    assert len(id_pos) == 66
+    id_neg = crypto.blinded_neg(id_pos)
+    assert len(id_neg) == 66
+    assert id_pos != id_neg
+    assert id_pos[:64] == id_neg[:64]
+    assert int(id_pos[64], 16) ^ int(id_neg[64], 16) == 0x8
+    assert id_pos[65] == id_neg[65]
+
+    assert blinded_id in (id_pos, id_neg)
+
+
+def test_blinded_transition(
+    db, client, room, room2, user, user2, mod, admin, global_mod, global_admin, banned_user
+):
+    r3 = Room.create('R3', name='R3', description='Another room')
+    r3.default_read = False
+    r3.default_write = False
+    r3.default_accessible = False
+    r3.default_upload = False
+
+    r3.set_moderator(user, added_by=global_admin, admin=True, visible=False)
+    r3.set_permissions(user2, mod=user, read=True, write=True, accessible=True, upload=True)
+    r3.set_permissions(mod, mod=user, read=True, accessible=True)
+
+    from user import User as TestUser
+
+    u3 = TestUser()
+
+    room.set_permissions(user, mod=global_admin, upload=False)
+    room.ban_user(user2, mod=global_mod, timeout=86400)
+    room2.set_permissions(user2, mod=global_admin, write=False, upload=False)
+    db.query(
+        """
+        INSERT INTO user_permission_futures (room, "user", at, write, upload)
+        VALUES (:r, :u, :at, :wr, :up)
+        """,
+        r=room.id,
+        u=user2.id,
+        wr=True,
+        up=True,
+        at=time.time() + 86400,
+    )
+
+    assert db.query("SELECT COUNT(*) FROM users").fetchone()[0] == 9
+    assert db.query("SELECT COUNT(*) FROM needs_blinding").fetchone()[0] == 0
+
+    assert [r[0] for r in db.query('SELECT "user" FROM user_permission_futures')] == [user2.id]
+    assert [r[0] for r in db.query('SELECT "user" FROM user_ban_futures')] == [user2.id]
+
+    with config_override(REQUIRE_BLIND_KEYS=True):
+        # Forcibly reinit, which should populate the blinding transition tables
+        db.database_init()
+
+        unmigrated = {
+            global_mod.id,
+            global_admin.id,
+            banned_user.id,
+            mod.id,
+            admin.id,
+            user.id,
+            user2.id,
+            # u3 is not in here because it isn't assigned any permissions that need migration
+        }
+        r1mods = (
+            [mod.session_id],
+            [admin.session_id],
+            [global_mod.session_id],
+            [global_admin.session_id],
+        )
+        r2mods = ([], [], [global_mod.session_id], [global_admin.session_id])
+        r3mods = (
+            [],
+            [],
+            [global_mod.session_id],
+            sorted((user.session_id, global_admin.session_id)),
+        )
+        assert unmigrated == set(r[0] for r in db.query('SELECT "user" FROM needs_blinding'))
+        assert room.get_mods(global_admin) == r1mods
+        assert room2.get_mods(global_admin) == r2mods
+        assert r3.get_mods(global_admin) == r3mods
+
+        from sogs.model.user import User
+
+        # Direct User construction of a new blinded user should transition:
+        b_mod = User(session_id=mod.blinded_id)
+        unmigrated.remove(mod.id)
+        assert unmigrated == set(r[0] for r in db.query('SELECT "user" FROM needs_blinding'))
+        r1mods[0][0] = b_mod.session_id
+        assert room.get_mods(global_admin) == r1mods
+
+        # Transition should occur on the first authenticated request:
+        r = client.get(
+            '/capabilities',
+            headers=x_sogs(user.ed_key, crypto.server_pubkey, 'GET', '/capabilities', blinded=True),
+        )
+        assert r.status_code == 200
+
+        unmigrated.remove(user.id)
+        assert unmigrated == set(r[0] for r in db.query('SELECT "user" FROM needs_blinding'))
+        r3mods[3].clear()
+        r3mods[3].extend(sorted((user.blinded_id, global_admin.session_id)))
+        assert room.get_mods(global_admin) == r1mods
+        assert room2.get_mods(global_admin) == r2mods
+        assert r3.get_mods(global_admin) == r3mods
+
+        for u in (user2, u3, admin, global_mod, global_admin, banned_user):
+            r = client.get(
+                '/capabilities',
+                headers=x_sogs(
+                    u.ed_key, crypto.server_pubkey, 'GET', '/capabilities', blinded=True
+                ),
+            )
+            # Banned user should still be banned after migration:
+            if u.id == banned_user.id:
+                assert r.status_code == 403
+            else:
+                assert r.status_code == 200
+            if u.id != u3.id:
+                unmigrated.remove(u.id)
+
+        assert unmigrated == set()
+
+        # NB: "global_admin" isn't actually an admin anymore (we transferred the permission to the
+        # blinded equivalent), so shouldn't see the invisible mods:
+        assert room.get_mods(global_admin) == ([mod.blinded_id], [admin.blinded_id], [], [])
+        assert room2.get_mods(global_admin) == ([], [], [], [])
+        assert r3.get_mods(global_admin) == ([], [], [], [])
+
+        r1mods = (
+            [mod.blinded_id],
+            [admin.blinded_id],
+            [global_mod.blinded_id],
+            [global_admin.blinded_id],
+        )
+        r2mods = ([], [], [global_mod.blinded_id], [global_admin.blinded_id])
+        r3mods = (
+            [],
+            [],
+            [global_mod.blinded_id],
+            sorted((user.blinded_id, global_admin.blinded_id)),
+        )
+
+        b_g_admin = User(session_id=global_admin.blinded_id)
+        assert room.get_mods(b_g_admin) == r1mods
+        assert room2.get_mods(b_g_admin) == r2mods
+        assert r3.get_mods(b_g_admin) == r3mods
+
+        b_u2 = User(session_id=user2.blinded_id)
+        assert [r[0] for r in db.query('SELECT "user" FROM user_permission_futures')] == [b_u2.id]
+        assert [r[0] for r in db.query('SELECT "user" FROM user_ban_futures')] == [b_u2.id]

--- a/tests/test_derived_key.py
+++ b/tests/test_derived_key.py
@@ -1,8 +1,0 @@
-def test_derived_key_generation(user):
-    assert user.session_id is not None
-    session_id = user.session_id
-    derived = user.derived_key
-    assert derived != session_id
-    assert derived[0:2] == '15'
-    assert session_id[0:2] == '05'
-    assert derived[2:] != session_id[2:]

--- a/tests/test_dm.py
+++ b/tests/test_dm.py
@@ -3,7 +3,7 @@ from sogs import config
 from sogs.hashing import blake2b
 from sogs.utils import encode_base64
 from sogs.model.user import SystemUser
-import nacl.bindings as salt
+import nacl.bindings as sodium
 from nacl.utils import random
 from util import from_now
 
@@ -25,12 +25,12 @@ def make_post(message, sender, to):
     a = sender.ed_key.to_curve25519_private_key().encode()
     kA = bytes.fromhex(sender.session_id[2:])
     kB = bytes.fromhex(to.session_id[2:])
-    key = blake2b(salt.crypto_scalarmult_ed25519_noclamp(a, kB) + kA + kB, digest_size=32)
+    key = blake2b(sodium.crypto_scalarmult_ed25519_noclamp(a, kB) + kA + kB, digest_size=32)
 
     # MESSAGE || UNBLINDED_ED_PUBKEY
     plaintext = message + sender.ed_key.verify_key.encode()
     nonce = random(24)
-    ciphertext = salt.crypto_aead_xchacha20poly1305_ietf_encrypt(
+    ciphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
         plaintext, aad=None, nonce=nonce, key=key
     )
     data = b'\x00' + ciphertext + nonce

--- a/tests/user.py
+++ b/tests/user.py
@@ -1,6 +1,6 @@
 import sogs.model.user
 from nacl.signing import SigningKey
-import nacl.bindings as salt
+import nacl.bindings as sodium
 from sogs.hashing import blake2b
 import sogs.crypto
 
@@ -11,11 +11,11 @@ class User(sogs.model.user.User):
 
         if blinded:
             a = self.ed_key.to_curve25519_private_key().encode()
-            k = salt.crypto_core_ed25519_scalar_reduce(
+            k = sodium.crypto_core_ed25519_scalar_reduce(
                 blake2b(sogs.crypto.server_pubkey_bytes, digest_size=64)
             )
-            ka = salt.crypto_core_ed25519_scalar_mul(k, a)
-            kA = salt.crypto_scalarmult_ed25519_base_noclamp(ka)
+            ka = sodium.crypto_core_ed25519_scalar_mul(k, a)
+            kA = sodium.crypto_scalarmult_ed25519_base_noclamp(ka)
             session_id = '15' + kA.hex()
         else:
             session_id = '05' + self.ed_key.to_curve25519_private_key().public_key.encode().hex()

--- a/tests/user.py
+++ b/tests/user.py
@@ -1,7 +1,6 @@
 import sogs.model.user
 from nacl.signing import SigningKey
 import nacl.bindings as sodium
-from sogs.hashing import blake2b
 import sogs.crypto
 
 
@@ -9,14 +8,12 @@ class User(sogs.model.user.User):
     def __init__(self, blinded=False):
         self.ed_key = SigningKey.generate()
 
+        self.a = self.ed_key.to_curve25519_private_key().encode()
+        self.ka = sodium.crypto_core_ed25519_scalar_mul(sogs.crypto.blinding_factor, self.a)
+        self.kA = sodium.crypto_scalarmult_ed25519_base_noclamp(self.ka)
+        self.blinded_id = '15' + self.kA.hex()
         if blinded:
-            a = self.ed_key.to_curve25519_private_key().encode()
-            k = sodium.crypto_core_ed25519_scalar_reduce(
-                blake2b(sogs.crypto.server_pubkey_bytes, digest_size=64)
-            )
-            ka = sodium.crypto_core_ed25519_scalar_mul(k, a)
-            kA = sodium.crypto_scalarmult_ed25519_base_noclamp(ka)
-            session_id = '15' + kA.hex()
+            session_id = self.blinded_id
         else:
             session_id = '05' + self.ed_key.to_curve25519_private_key().public_key.encode().hex()
 


### PR DESCRIPTION
Adds migration of unblinded user permissions to blinded user permissions on first login.

This works more or less as described in #73 (though needed some changes in practice, such as me not thinking about global mods and permission futures in #73): when sogs starts up we build a list of *positive* alternative blinded keys for each unblinded user we have with permissions set somewhere (moderator, custom permissions, bans, etc.), then on first login with either ± blinded alternative we move all applied permissions from the unblinded user to a new blinded user row.

Draft because there's still once piece to go: when we *add* permissions (or futures) to an unblinded id we need to either immediately translate those to the blinded id (if we have already seen it), or else insert it in the needs_blinding table for conversion on first blinded login.

Fixes #73