### PR TITLE
Setting advanced room permissions

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,11 +1,3 @@
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Copyright (c) 2021 The Oxen Project
-
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -1046,37 +1046,35 @@ class Room:
             raise BadPermission()
 
         with db.transaction():
-            need_blinding = False
-            if config.REQUIRE_BLIND_KEYS:
-                blinded = user.find_blinded()
-                if blinded is not None:
-                    user = blinded
-                else:
-                    need_blinding = True
+            with user.check_blinding() as u:
+                query(
+                    f"""
+                    INSERT INTO user_permission_overrides
+                        (room,
+                        "user",
+                        moderator,
+                        {'admin,' if admin is not None else ''}
+                        visible_mod)
+                    VALUES (:r, :u, TRUE, {':admin,' if admin is not None else ''} :visible)
+                    ON CONFLICT (room, "user") DO UPDATE SET
+                        moderator = excluded.moderator,
+                        {'admin = excluded.admin,' if admin is not None else ''}
+                        visible_mod = excluded.visible_mod
+                    """,
+                    r=self.id,
+                    u=u.id,
+                    admin=admin,
+                    visible=visible,
+                )
+                if u.id in self._perm_cache:
+                    del self._perm_cache[u.id]
 
-            query(
-                f"""
-                INSERT INTO user_permission_overrides
-                    (room, "user", moderator, {'admin,' if admin is not None else ''} visible_mod)
-                VALUES (:r, :u, TRUE, {':admin,' if admin is not None else ''} :visible)
-                ON CONFLICT (room, "user") DO UPDATE SET
-                    moderator = excluded.moderator,
-                    {'admin = excluded.admin,' if admin is not None else ''}
-                    visible_mod = excluded.visible_mod
-                """,
-                r=self.id,
-                u=user.id,
-                admin=admin,
-                visible=visible,
-            )
+                if u.id in self._perm_cache:
+                    del self._perm_cache[u.id]
 
-            if need_blinding:
-                user.record_needs_blinding()
-
-        if user.id in self._perm_cache:
-            del self._perm_cache[user.id]
-
-        app.logger.info(f"{added_by} set {user} as {'admin' if admin else 'moderator'} of {self}")
+                app.logger.info(
+                    f"{added_by} set {u} as {'admin' if admin else 'moderator'} of {self}"
+                )
 
     def remove_moderator(self, user: User, *, removed_by: User, remove_admin_only: bool = False):
         """
@@ -1120,67 +1118,58 @@ class Room:
         """
 
         with db.transaction():
-            need_blinding = False
-            if config.REQUIRE_BLIND_KEYS:
-                blinded = to_ban.find_blinded()
-                if blinded is not None:
-                    to_ban = blinded
-                else:
-                    need_blinding = True
+            with to_ban.check_blinding() as to_ban:
+                fail = None
+                if not self.check_moderator(mod):
+                    fail = "user is not a moderator"
+                elif to_ban.id == mod.id:
+                    fail = "self-ban not permitted"
+                elif to_ban.global_moderator:
+                    fail = "global mods/admins cannot be banned"
+                elif self.check_moderator(to_ban) and not self.check_admin(mod):
+                    fail = "only admins can ban room mods/admins"
 
-            fail = None
-            if not self.check_moderator(mod):
-                fail = "user is not a moderator"
-            elif to_ban.id == mod.id:
-                fail = "self-ban not permitted"
-            elif to_ban.global_moderator:
-                fail = "global mods/admins cannot be banned"
-            elif self.check_moderator(to_ban) and not self.check_admin(mod):
-                fail = "only admins can ban room mods/admins"
+                if fail is not None:
+                    app.logger.warning(f"Error banning {to_ban} from {self} by {mod}: {fail}")
+                    raise BadPermission()
 
-            if fail is not None:
-                app.logger.warning(f"Error banning {to_ban} from {self} by {mod}: {fail}")
-                raise BadPermission()
+                # TODO: log the banning action for auditing
 
-            # TODO: log the banning action for auditing
-
-            query(
-                """
-                INSERT INTO user_permission_overrides (room, "user", banned, moderator, admin)
-                    VALUES (:r, :ban, TRUE, FALSE, FALSE)
-                ON CONFLICT (room, "user") DO
-                    UPDATE SET banned = TRUE, moderator = FALSE, admin = FALSE
-                """,
-                r=self.id,
-                ban=to_ban.id,
-            )
-
-            # Replace (or remove) an existing scheduled unban:
-            query(
-                'DELETE FROM user_ban_futures WHERE room = :r AND "user" = :u AND NOT banned',
-                r=self.id,
-                u=to_ban.id,
-            )
-            if timeout:
                 query(
                     """
-                    INSERT INTO user_ban_futures
-                    (room, "user", banned, at) VALUES (:r, :u, FALSE, :at)
+                    INSERT INTO user_permission_overrides (room, "user", banned, moderator, admin)
+                        VALUES (:r, :ban, TRUE, FALSE, FALSE)
+                    ON CONFLICT (room, "user") DO
+                        UPDATE SET banned = TRUE, moderator = FALSE, admin = FALSE
                     """,
                     r=self.id,
-                    u=to_ban.id,
-                    at=time.time() + timeout,
+                    ban=to_ban.id,
                 )
 
-            if need_blinding:
-                to_ban.record_needs_blinding()
+                # Replace (or remove) an existing scheduled bans/unbans:
+                query(
+                    'DELETE FROM user_ban_futures WHERE room = :r AND "user" = :u',
+                    r=self.id,
+                    u=to_ban.id,
+                )
+                if timeout:
+                    query(
+                        """
+                        INSERT INTO user_ban_futures
+                        (room, "user", banned, at) VALUES (:r, :u, FALSE, :at)
+                        """,
+                        r=self.id,
+                        u=to_ban.id,
+                        at=time.time() + timeout,
+                    )
 
-        if to_ban.id in self._perm_cache:
-            del self._perm_cache[to_ban.id]
+                if to_ban.id in self._perm_cache:
+                    del self._perm_cache[to_ban.id]
 
-        app.logger.debug(
-            f"Banned {to_ban} from {self} {f'for {timeout}s ' if timeout else ''}(banned by {mod})"
-        )
+                app.logger.debug(
+                    f"Banned {to_ban} from {self} {f'for {timeout}s ' if timeout else ''}"
+                    f"(banned by {mod})"
+                )
 
     def unban_user(self, to_unban: User, *, mod: User):
         """
@@ -1257,37 +1246,119 @@ class Room:
             raise BadPermission()
 
         with db.transaction():
-            need_blinding = False
-            if config.REQUIRE_BLIND_KEYS:
-                blinded = user.find_blinded()
-                if blinded is not None:
-                    user = blinded
-                else:
-                    need_blinding = True
+            with user.check_blinding() as user:
+                set_perms = perms.keys()
+                query(
+                    f"""
+                    INSERT INTO user_permission_overrides (room, "user", {', '.join(set_perms)})
+                    VALUES (:r, :u, :{', :'.join(set_perms)})
+                    ON CONFLICT (room, "user") DO UPDATE SET
+                        {', '.join(f"{p} = :{p}" for p in set_perms)}
+                    """,
+                    r=self.id,
+                    u=user.id,
+                    read=perms.get('read'),
+                    accessible=perms.get('accessible'),
+                    write=perms.get('write'),
+                    upload=perms.get('upload'),
+                )
 
-            set_perms = perms.keys()
-            query(
-                f"""
-                INSERT INTO user_permission_overrides (room, "user", {', '.join(set_perms)})
-                VALUES (:r, :u, :{', :'.join(set_perms)})
-                ON CONFLICT (room, "user") DO UPDATE SET
-                    {', '.join(f"{p} = :{p}" for p in set_perms)}
-                """,
-                r=self.id,
-                u=user.id,
-                read=perms.get('read'),
-                accessible=perms.get('accessible'),
-                write=perms.get('write'),
-                upload=perms.get('upload'),
-            )
+                if user.id in self._perm_cache:
+                    del self._perm_cache[user.id]
 
-            if need_blinding:
-                user.record_needs_blinding()
+                app.logger.debug(f"{mod} applied {self} permission(s) {perms} to {user}")
 
-        if user.id in self._perm_cache:
-            del self._perm_cache[user.id]
+    def clear_future_permissions(
+        self,
+        user: User,
+        *,
+        mod: User,
+        read: bool = False,
+        write: bool = False,
+        upload: bool = False,
+    ):
+        """
+        Clears any scheduled room permissions changes for this user that change the read and/or
+        write and/or upload permissions.
 
-        app.logger.debug(f"{mod} applied {self} permission(s) {perms} to {user}")
+        This only removes the requested permission flags; for instance, if called with `read=True,
+        write=True` and a future permission is scheduled that sets `read=true, write=false,
+        upload=true` then the upload=true scheduled override will remain and the read/write
+        scheduled changes will be removed.
+
+        Also note that this removes *all* scheduled changes if there are multiple scheduled changes.
+        """
+
+        sets = []
+        if read:
+            sets.append("read = NULL")
+        if write:
+            sets.append("write = NULL")
+        if upload:
+            sets.append("upload = NULL")
+
+        if not sets:
+            return
+
+        with db.transaction():
+            with user.check_blinding() as u:
+                r = query(
+                    f"""
+                    UPDATE user_permission_futures
+                    SET {', '.join(sets)}
+                    WHERE room = :r AND "user" = :u
+                    """,
+                    r=self.id,
+                    u=u.id,
+                )
+
+                # Clear any rows that we updated to all-nulls:
+                if r.rowcount > 0:
+                    query(
+                        """
+                        DELETE FROM user_permission_futures
+                        WHERE room = :r AND "user" = :u AND
+                            read = NULL AND write = NULL AND upload = NULL
+                        """,
+                        r=self.id,
+                        u=u.id,
+                    )
+
+    def add_future_permission(
+        self,
+        user,
+        *,
+        at: float,
+        mod: User,
+        read: Optional[bool] = None,
+        write: Optional[bool] = None,
+        upload: Optional[bool] = None,
+    ):
+        """
+        Schedules a future permission change for the given user in this room.
+
+        The permission change will occur at (or within a few seconds of) the unix timestamp given in
+        `at`, and will set read, write, and/or upload to the given boolean values.  (None values are
+        left unchanged).
+        """
+
+        if not any(x is not None for x in (read, write, upload)):
+            return
+
+        with db.transaction():
+            with user.check_blinding() as u:
+                query(
+                    """
+                    INSERT INTO user_permission_futures (room, "user", at, read, write, upload)
+                    VALUES (:r, :u, :at, :read, :write, :upload)
+                    """,
+                    r=self.id,
+                    u=u.id,
+                    at=at,
+                    read=read,
+                    write=write,
+                    upload=upload,
+                )
 
     def get_file(self, file_id: int):
         """Retrieves a file uploaded to this room by id.  Returns None if not found."""
@@ -1522,6 +1593,23 @@ class Room:
             ret[row['session_id']] = data
         return ret
 
+    def user_permissions(self, user):
+        """
+        Returns assigned room permissions for the given user.  Note that this does not reflect
+        default permissions, but rather only permissions that have been specifically granted or
+        revoked for this user.
+        """
+        row = query(
+            'SELECT * from user_permission_overrides WHERE "user" = :u AND room = :r',
+            u=user.id,
+            r=self.id,
+        ).fetchone()
+        if not row:
+            return {}
+        return {
+            k: bool(row[k]) for k in row.keys() if k not in ('room', 'user') and row[k] is not None
+        }
+
     @property
     def future_permissions(self):
         """
@@ -1529,18 +1617,23 @@ class Room:
         """
         ret = list()
         for row in query(
-            """SELECT session_id, futures.* FROM (
-        SELECT "user", at, read, write, upload, null AS banned
-        FROM user_permission_futures WHERE room = :r
-        UNION ALL
-        SELECT "user", at, null AS read, null AS write, null AS upload, banned
-        FROM user_ban_futures WHERE room = :r
-        ) futures JOIN users ON futures."user" = users.id""",
+            """
+            SELECT session_id, futures.* FROM (
+                SELECT "user", at, read, write, upload, NULL AS banned
+                FROM user_permission_futures WHERE room = :r
+
+                UNION ALL
+
+                SELECT "user", at, NULL AS read, NULL AS write, NULL AS upload, banned
+                FROM user_ban_futures WHERE room = :r
+            ) futures JOIN users ON futures."user" = users.id
+            ORDER BY at
+            """,
             r=self.id,
         ):
             data = dict()
             for k in row.keys():
-                if k in ('room', 'user'):
+                if k == 'user':
                     continue
                 if k in ('at', 'session_id'):
                     data[k] = row[k]
@@ -1548,6 +1641,32 @@ class Room:
                     data[k] = bool(row[k])
             ret.append(data)
         return ret
+
+    def user_future_permissions(self, user):
+        """
+        Returns a list of any scheduled future permission changes for the given user in this room
+        (note that this includes bans as well as the read/write/upload permissions).
+        """
+        result = []
+        for row in query(
+            """
+            SELECT * FROM (
+                SELECT at, read, write, upload, null AS banned
+                FROM user_permission_futures WHERE room = :r AND "user" = :u
+
+                UNION ALL
+
+                SELECT at, NULL AS read, NULL AS write, NULL AS upload, banned
+                FROM user_ban_futures WHERE room = :r AND "user" = :u
+            ) futures ORDER BY at
+            """,
+            u=user.id,
+            r=self.id,
+        ):
+            result.append({k: bool(row[k]) for k in row.keys() if k != 'at' and row[k] is not None})
+            result[-1]['at'] = row['at']
+
+        return result
 
 
 def get_rooms():

--- a/sogs/routes/general.py
+++ b/sogs/routes/general.py
@@ -37,19 +37,27 @@ def get_caps():
     return jsonify(res), res_code
 
 
-def parse_batch_request(req):
-    """
-    Checks a batch request dict for the required fields:
+batch_args = """
+    Each individual batch subrequest is a list of dicts containing keys:
 
-    - method is required and must be one of GET/DELETE/POST/PUT
-    - path is required and must begin with a /
+    - `method` is required and must be one of GET/DELETE/POST/PUT
+    - `path` is required and must begin with a /
     - for POST/PUT requests there must be exactly one of:
-        - a json value under the 'json' key
-        - a base64-encoded body under the 'b64' key
-        - a raw bytes value under the 'bytes' key (not recommended for json)
-    - headers may be provided, and must be a dict of k/v string pairs if provided.
+        - a json value under the `json` key
+        - a base64-encoded body under the `b64` key
+        - a raw bytes value under the `bytes` key (not recommended for json)
+    - `headers` may be provided, and must be a dict of k/v string pairs if provided.
 
-    If non-conforming data is encountered then a BAD_REQUEST request abort is raised.
+    If non-conforming data is encountered then the request is terminated with a Bad Request error
+    code.
+"""
+
+
+def parse_batch_request(req):
+    f"""
+    Checks a batch request dict for the required fields.
+
+    {batch_args}
 
     Returns (method, path, headers, json, body).  `headers` will be a dict (empty if no headers were
     provided); `json`/`body` will be None for GET/DELETE requests; `json` will simply be the `json`
@@ -124,6 +132,12 @@ def batch(_sequential=False):
     be attempted.  There is no guarantee on the order in which requests will be carried out.  (For
     sequential, related requests invoke via /sequence instead).
 
+    # Body
+
+    {batch_args}
+
+    # Return value
+
     Returns a list of responses in the same order as the provided requests; each response consists
     of a dict containing:
     - code -- the numeric http response code (e.g. 200 for success)
@@ -171,6 +185,8 @@ def sequence():
     Like batch, responses are returned in the same order as requests, but unlike batch there may be
     fewer elements in the response list (if requests were stopped because of a non-2xx response).
     In such a case, the final, non-2xx response is still included as the final response value.
+
+    See [`/batch`](#post-batch) for arguments and response.
     """
 
     return batch(_sequential=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -274,13 +274,13 @@ def test_auth_malformed(client, db):
 
     # Bad timestamps
     r = client.get(
-        "/auth_test/whoami", headers=x_sogs(a, B, 'GET', '/auth_test/whoami', timestamp_off=86401)
+        "/auth_test/whoami", headers=x_sogs(a, B, 'GET', '/auth_test/whoami', timestamp_off=86402)
     )
     assert r.status_code == 425
     assert r.data == b'Invalid authentication: X-SOGS-Timestamp is too far from current time'
 
     r = client.get(
-        "/auth_test/whoami", headers=x_sogs(a, B, 'GET', '/auth_test/whoami', timestamp_off=-86401)
+        "/auth_test/whoami", headers=x_sogs(a, B, 'GET', '/auth_test/whoami', timestamp_off=-86402)
     )
     assert r.status_code == 425
     assert r.data == b'Invalid authentication: X-SOGS-Timestamp is too far from current time'

--- a/tests/test_room_routes.py
+++ b/tests/test_room_routes.py
@@ -2,11 +2,13 @@ import pytest
 import time
 from sogs.model.room import Room
 from sogs.model.file import File
-from sogs import utils
+from sogs import utils, crypto
 import sogs.config
 import werkzeug.exceptions as wexc
-from util import pad64, from_now
+from util import pad64, from_now, config_override
+from auth import x_sogs
 from request import sogs_get, sogs_post, sogs_put, sogs_post_raw, sogs_delete
+import json
 
 
 def test_list(client, room, room2, user, user2, admin, mod, global_mod, global_admin):
@@ -659,15 +661,21 @@ def test_fetch_one(client, room, user, no_rate_limit):
         assert r.json == p
 
 
-time_fields = {'posted', 'edited', 'pinned_at'}
+time_fields = {'posted', 'edited', 'pinned_at', 'at'}
 
 
 def filter_timestamps(x, fields=time_fields):
-    """Filters timestamp fields out of a dict or list of dicts for easier comparing of everything
-    except timestamps"""
+    """
+    Filters timestamp keys out of a dict or list of dicts (recursively) for easier comparing of
+    everything except timestamps.
+    """
     if isinstance(x, list):
         return [filter_timestamps(y, fields) for y in x]
-    return {k: v for k, v in x.items() if k not in fields}
+    return {
+        k: filter_timestamps(v, fields) if isinstance(v, list) or isinstance(v, dict) else v
+        for k, v in x.items()
+        if k not in fields
+    }
 
 
 def test_pinning(client, room, user, admin, no_rate_limit):
@@ -1142,12 +1150,12 @@ def test_remove_all_self_posts_from_room(client, room, mod, user, no_rate_limit)
 
 
 def test_get_room_perms(client, room, user):
-    r = sogs_get(client, f'/room/{room.token}/permInfo', user)
+    r = sogs_get(client, f'/room/{room.token}/permissions', user)
     assert r.status_code == 403
 
 
 def test_get_room_perms_as_mod(client, room, mod):
-    r = sogs_get(client, f'/room/{room.token}/permInfo', mod)
+    r = sogs_get(client, f'/room/{room.token}/permissions', mod)
     assert r.status_code == 200
     assert mod.session_id in r.json
     perm_info = r.json[mod.session_id]
@@ -1155,7 +1163,7 @@ def test_get_room_perms_as_mod(client, room, mod):
 
 
 def test_get_room_perms_as_admin(client, room, admin):
-    r = sogs_get(client, f'/room/{room.token}/permInfo', admin)
+    r = sogs_get(client, f'/room/{room.token}/permissions', admin)
     assert r.status_code == 200
     assert admin.session_id in r.json
     perm_info = r.json[admin.session_id]
@@ -1163,11 +1171,356 @@ def test_get_room_perms_as_admin(client, room, admin):
 
 
 def test_get_room_future_perms(client, room, mod):
-    r = sogs_get(client, f'/room/{room.token}/futurePermInfo', mod)
+    r = sogs_get(client, f'/room/{room.token}/futurePermissions', mod)
     assert r.status_code == 200
     assert r.json == []
 
 
 def test_get_room_future_perms_not_allowed(client, room, user):
-    r = sogs_get(client, f'/room/{room.token}/futurePermInfo', user)
+    r = sogs_get(client, f'/room/{room.token}/futurePermissions', user)
     assert r.status_code == 403
+
+
+def test_set_room_perms(client, room, user, mod):
+    r = sogs_post(
+        client,
+        f'/room/{room.token}/permissions/{user.session_id}',
+        {'read': True, 'write': False},
+        mod,
+    )
+
+    assert r.status_code == 200
+    assert r.json == {"read": True, "write": False}
+
+    r = sogs_post(
+        client, f'/room/{room.token}/permissions/{user.session_id}', {'default_read': True}, mod
+    )
+    assert r.status_code == 200
+    assert r.json == {"write": False}
+
+    r = sogs_post(
+        client,
+        f'/room/{room.token}/permissions/{user.session_id}',
+        {'default_read': True, 'write': False, 'upload': False, 'accessible': True},
+        mod,
+    )
+    assert r.status_code == 200
+    assert r.json == {"write": False, 'upload': False, 'accessible': True}
+
+    r = sogs_get(client, f'/room/{room.token}/permissions', mod)
+    assert r.status_code == 200
+    assert r.json == {
+        mod.session_id: {'moderator': True},
+        user.session_id: {"write": False, 'upload': False, 'accessible': True},
+    }
+
+    r = sogs_get(client, f'/room/{room.token}/permissions/{user.session_id}', mod)
+    assert r.status_code == 200
+    assert r.json == {"write": False, "upload": False, "accessible": True}
+
+    r = sogs_post(
+        client,
+        f'/room/{room.token}/permissions/{user.session_id}',
+        {'default_' + x: True for x in ('read', 'write', 'upload', 'accessible')},
+        mod,
+    )
+    assert r.status_code == 200
+    assert r.json == {}
+
+
+def test_set_room_perm_futures(client, room, user, mod):
+
+    r = sogs_post(
+        client,
+        '/sequence',
+        [
+            {
+                'method': 'POST',
+                'path': f'/room/{room.token}/permissions/{user.session_id}',
+                'json': {'read': True, 'write': False, 'upload': False, 'accessible': True},
+            },
+            {
+                'method': 'POST',
+                'path': f'/room/{room.token}/futurePermissions/{user.session_id}',
+                'json': {'write': True, 'upload': True, 'in': 0.001},
+            },
+        ],
+        mod,
+    )
+    assert filter_timestamps(r.json) == [
+        {
+            'code': 200,
+            'headers': {'content-type': 'application/json'},
+            'body': {'read': True, 'write': False, 'upload': False, 'accessible': True},
+        },
+        {
+            "code": 200,
+            'headers': {'content-type': 'application/json'},
+            'body': [{'upload': True, 'write': True}],
+        },
+    ]
+
+    assert r.json[1]['body'][0]['at'] == from_now.seconds(0.001)
+    time.sleep(0.002)
+
+    r = sogs_get(client, f'/room/{room.token}/futurePermissions', mod)
+    assert r.status_code == 200
+    assert filter_timestamps(r.json) == [
+        {'session_id': user.session_id, 'upload': True, 'write': True}
+    ]
+    assert r.json[0]['at'] == from_now.seconds(0.001)
+
+    r = sogs_post(
+        client,
+        f'/room/{room.token}/futurePermissions/{user.session_id}',
+        {'in': 30, 'write': False, 'upload': False, 'read': False},
+        mod,
+    )
+    assert r.status_code == 200
+    assert filter_timestamps(r.json) == [
+        {'upload': True, 'write': True},
+        {'upload': False, 'write': False, 'read': False},
+    ]
+    assert r.json[0]['at'] == from_now.seconds(0.001)
+    assert r.json[1]['at'] == from_now.seconds(30)
+
+    from sogs.cleanup import cleanup
+
+    assert cleanup() == (0, 0, 0, 1, 0)
+
+    r = sogs_get(client, f'/room/{room.token}/permissions/{user.session_id}', mod)
+    assert r.status_code == 200
+    assert r.json == {'read': True, 'accessible': True}
+
+    r = sogs_get(client, f'/room/{room.token}/futurePermissions/{user.session_id}', mod)
+    assert r.status_code == 200
+    assert filter_timestamps(r.json) == [{'upload': False, 'write': False, 'read': False}]
+    assert r.json[0]['at'] == from_now.seconds(29.999)
+
+    r = sogs_get(client, f'/room/{room.token}/permissions', mod)
+    assert r.status_code == 200
+    assert r.json == {
+        user.session_id: {'read': True, 'accessible': True},
+        mod.session_id: {'moderator': True},
+    }
+
+    r = sogs_get(client, f'/room/{room.token}/futurePermissions', mod)
+    assert r.status_code == 200
+    assert filter_timestamps(r.json) == [
+        {'session_id': user.session_id, 'upload': False, 'write': False, 'read': False}
+    ]
+    assert r.json[0]['at'] == from_now.seconds(29.999)
+
+    r = sogs_get(client, f'/room/{room.token}/permissions/{user.session_id}', user)
+    assert r.status_code == 403
+    r = sogs_get(client, f'/room/{room.token}/futurePermissions/{user.session_id}', user)
+    assert r.status_code == 403
+
+
+def test_set_room_perms_blinding(client, db, room, user, user2, mod):
+    with config_override(REQUIRE_BLIND_KEYS=True):
+        db.database_init()
+
+        # Authenticate `user` so that the sogs knows about user's session id before we set up
+        # permissions (to make sure they go to the *blinded* id even when we specify the unblinded
+        # id):
+        r = client.get(
+            f'/room/{room.token}',
+            headers=x_sogs(
+                user.ed_key, crypto.server_pubkey, 'GET', f'/room/{room.token}', blinded=True
+            ),
+        )
+        assert r.status_code == 200
+
+        body = json.dumps(
+            [
+                {
+                    'method': 'POST',
+                    'path': f'/room/{room.token}/permissions/{user.session_id}',
+                    'json': {'read': True, 'write': False},
+                },
+                {
+                    'method': 'POST',
+                    'path': f'/room/{room.token}/futurePermissions/{user.session_id}',
+                    'json': {'write': True, 'in': 0.001},
+                },
+                {
+                    'method': 'POST',
+                    'path': f'/room/{room.token}/permissions/{user2.session_id}',
+                    'json': {'upload': False},
+                },
+                {
+                    'method': 'POST',
+                    'path': f'/room/{room.token}/futurePermissions/{user2.session_id}',
+                    'json': {'upload': True, 'in': 0.002},
+                },
+            ]
+        ).encode()
+        r = client.post(
+            '/sequence',
+            headers=x_sogs(
+                mod.ed_key, crypto.server_pubkey, 'POST', '/sequence', body, blinded=True
+            ),
+            content_type='application/json',
+            data=body,
+        )
+        assert r.status_code == 200
+        assert filter_timestamps(r.json) == [
+            {
+                'code': 200,
+                'headers': {'content-type': 'application/json'},
+                'body': {'read': True, 'write': False},
+            },
+            {
+                "code": 200,
+                'headers': {'content-type': 'application/json'},
+                'body': [{'write': True}],
+            },
+            {
+                'code': 200,
+                'headers': {'content-type': 'application/json'},
+                'body': {'upload': False},
+            },
+            {
+                "code": 200,
+                'headers': {'content-type': 'application/json'},
+                'body': [{'upload': True}],
+            },
+        ]
+
+        assert r.json[1]['body'][0]['at'] == from_now.seconds(0.001)
+        assert r.json[3]['body'][0]['at'] == from_now.seconds(0.002)
+
+        r = client.get(
+            f'/room/{room.token}/permissions',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/permissions',
+                blinded=True,
+            ),
+        )
+        assert r.status_code == 200
+        assert r.json == {
+            # user has a known blinded id so should have been inserted blinded:
+            user.blinded_id: {'read': True, 'write': False},
+            # user2 doesn't, so would be set up unblinded:
+            user2.session_id: {'upload': False},
+            mod.blinded_id: {'moderator': True},
+        }
+
+        r = client.get(
+            f'/room/{room.token}/futurePermissions',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/futurePermissions',
+                blinded=True,
+            ),
+        )
+        assert r.status_code == 200
+        assert filter_timestamps(r.json) == [
+            {'session_id': user.blinded_id, 'write': True},
+            {'session_id': user2.session_id, 'upload': True},
+        ]
+        assert r.json[0]['at'] == from_now.seconds(0.001)
+        assert r.json[1]['at'] == from_now.seconds(0.002)
+
+        # Authenticate user2, which should auto-convert the unblinded perm and future to the blinded
+        # id:
+        r = client.get(
+            f'/room/{room.token}',
+            headers=x_sogs(
+                user2.ed_key, crypto.server_pubkey, 'GET', f'/room/{room.token}', blinded=True
+            ),
+        )
+        assert r.status_code == 200
+
+        r = client.get(
+            f'/room/{room.token}/permissions',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/permissions',
+                blinded=True,
+            ),
+        )
+        assert r.status_code == 200
+        assert r.json == {
+            user.blinded_id: {'read': True, 'write': False},
+            user2.blinded_id: {'upload': False},
+            mod.blinded_id: {'moderator': True},
+        }
+
+        r = client.get(
+            f'/room/{room.token}/futurePermissions',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/futurePermissions',
+                blinded=True,
+            ),
+        )
+        assert r.status_code == 200
+        assert filter_timestamps(r.json) == [
+            {'session_id': user.blinded_id, 'write': True},
+            {'session_id': user2.blinded_id, 'upload': True},
+        ]
+        assert r.json[0]['at'] == from_now.seconds(0.001)
+        assert r.json[1]['at'] == from_now.seconds(0.002)
+
+        # GETting either blinded or unblinded should give us back the same permissions:
+        r = client.get(
+            f'/room/{room.token}/permissions/{user.session_id}',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/permissions/{user.session_id}',
+                blinded=True,
+            ),
+        )
+        assert r.status_code == 200
+        assert r.json == {'read': True, 'write': False}
+        r2 = client.get(
+            f'/room/{room.token}/permissions/{user.blinded_id}',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/permissions/{user.blinded_id}',
+                blinded=True,
+            ),
+        )
+        assert r2.status_code == 200
+        assert r2.json == r.json
+
+        r = client.get(
+            f'/room/{room.token}/futurePermissions/{user2.session_id}',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/futurePermissions/{user2.session_id}',
+                blinded=True,
+            ),
+        )
+        assert r.status_code == 200
+        assert filter_timestamps(r.json) == [{'upload': True}]
+        assert r.json[0]['at'] == from_now.seconds(0.002)
+        r2 = client.get(
+            f'/room/{room.token}/futurePermissions/{user2.blinded_id}',
+            headers=x_sogs(
+                mod.ed_key,
+                crypto.server_pubkey,
+                'GET',
+                f'/room/{room.token}/futurePermissions/{user2.blinded_id}',
+                blinded=True,
+            ),
+        )
+        assert r2.status_code == 200
+        assert r2.json == r.json


### PR DESCRIPTION
Adds omitted endpoints for setting user permissions and schedule user permission futures.

See the added docstrings for the details on how the API works.

Also in this PR are some other closely related changes:
- Make future permissions restore room defaults, when applicable
- DRY out the `need_blinding` code by adding a context manager for
  blinded User retrieval.  (The resulting indent adds a lot of code
  churn; ignore-whitespace-diff recommended for sanity)
- renamed permInfo and futurePermInfo (in endpoint names) to permissions
  and futurePermissions so that they are consistent with the new POST
  endpoint names for assigning permissions/futures.
- added GET /room/R/permissions/SESSIONID and
  /room/R/futurePermissions/SESSIONID endpoints that return the
  permissions and future permissions for a single session id.  (These
  share the same name with the POST endpoints that assign, and were
  cheap to add).
- make sure everything works through blinding transitions (i.e. you can
  specify an unblinded ID and properly adjust the *blinded* user).
- sort future permission retrieval by `at` time to make sure the
  response is deterministic.
- Added a bunch of tests
- (not really related, but I noticed when constructing a batch request): Make the generated /batch docs better