### PR TITLE
Avoid 'mentioned' users having their Session id exposed via room page.

### DIFF
--- a/sogs/static/view_room.js
+++ b/sogs/static/view_room.js
@@ -53,7 +53,7 @@ const setup = async () => {
                     }
 
                     const plain = Message.decode(data).dataMessage;
-                    e.appendChild(document.createTextNode(plain.profile.displayName +": "+plain.body));
+                    e.appendChild(document.createTextNode(plain.profile.displayName +": "+plain.body.replace(/@05[\da-f]{64}/g, '@hidden')));
                     elem.appendChild(e);
 
                 }


### PR DESCRIPTION
Currently, an @-mention causes the Session id of the mentioned user to be exposed via the room page, viewable in a browser if the default of `http_show_recent = yes` has not been disabled in `/etc/sogs/sogs.ini`.

This allows a would-be attacker to @-mention his victim in an open group, and then read his Session id using a browser.

This patch replaces instances of that Session id with `@hidden`:

<img width="307" alt="image" src="https://user-images.githubusercontent.com/749942/167430540-b359d520-d599-48c4-9bcb-7d726b0a3d7b.png">
