### PR TITLE
Catch exception when blinding fails

### DIFF
--- a/sogs/db.py
+++ b/sogs/db.py
@@ -218,7 +218,12 @@ def check_needs_blinding(dbconn):
             """,
             dbconn=dbconn,
         ):
-            pos_derived = crypto.compute_blinded_abs_id(sid)
+            try:
+                pos_derived = crypto.compute_blinded_abs_id(sid)
+            except Exception as e:
+                logging.warning(f"Failed to blind session_id {sid}: {e}")
+                continue
+
             query(
                 'INSERT INTO needs_blinding (blinded_abs, "user") VALUES (:blinded, :uid)',
                 blinded=pos_derived,


### PR DESCRIPTION
If there is some invalid session_id it could result in sodium failing
the blinding calculation; in such a case just warn and skip it.