### PR TITLE
Avoid PIL deprecation warning

### DIFF
--- a/sogs/routes/views.py
+++ b/sogs/routes/views.py
@@ -9,7 +9,12 @@ from io import BytesIO
 
 import qrencode
 
-from PIL.Image import NEAREST
+import PIL.Image
+
+if hasattr(PIL.Image, 'Resampling'):
+    NEAREST = PIL.Image.Resampling.NEAREST
+else:
+    NEAREST = PIL.Image.NEAREST
 
 
 views = Blueprint('views', __name__)


### PR DESCRIPTION
PIL loudly deprecated (with a quite short deprecation window) the
Image.NEAREST export.  Handle it for both new/old versions.