### PR TITLE
Don't try blinding already-blinded users

### DIFF
--- a/sogs/__main__.py
+++ b/sogs/__main__.py
@@ -282,6 +282,7 @@ elif args.add_moderators:
                 rooms = [Room(token=r) for r in args.rooms]
             except NoSuchRoom as nsr:
                 print(f"No such room: '{nsr.token}'", file=sys.stderr)
+                sys.exit(1)
 
         for sid in args.add_moderators:
             u = User(session_id=sid, try_blinding=True)

--- a/sogs/db.py
+++ b/sogs/db.py
@@ -215,6 +215,7 @@ def check_needs_blinding(dbconn):
                 EXCEPT
                 SELECT "user" FROM needs_blinding
             )
+            AND session_id LIKE '05%'
             """,
             dbconn=dbconn,
         ):


### PR DESCRIPTION
Some of the unions in the subselect here can return already-blinded
users, which we would then try to re-blind, which fails.  This avoids
selecting them.