### PR TITLE
Unicode onion request and auth fixes

### DIFF
--- a/sogs/__init__.py
+++ b/sogs/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.2.dev0"
+__version__ = "0.3.3.dev0"

--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -1130,7 +1130,7 @@ class Room:
                 app.logger.warning("No reaction provided")
                 raise InvalidData()
         elif not isinstance(reaction, str) or not 1 <= len(reaction) <= 12:
-            app.logger.warning("Invalid reaction string '{reaction}'")
+            app.logger.warning(f"Invalid reaction string '{reaction}'")
             raise InvalidData()
 
         if user_required and not user:

--- a/sogs/routes/auth.py
+++ b/sogs/routes/auth.py
@@ -80,6 +80,15 @@ from functools import wraps
 # For batch requests the X-SOGS-* headers are applied once, on the outermost batch request, *not* on
 # the individual subrequests; the authorization applies to all subrequests.
 #
+# If `PATH` contains URL-encoded characters then the signature applies to the post-decoded value,
+# e.g. a request for `GET /foo/%F0%9F%8D%8D%20%20%20%f0%9f%8d%8c` would expect the PATH component in
+# the signature to be the utf8-encoded bytes of `/foo/🍍   🍌`.  (This is unfortunately necessary
+# because HTTP request URL encoding rules are non-unique and could get converted between equivalent
+# representations in transit).  If passing through an *onion request* then you may optionally avoid
+# URL-encoding entirely: the endpoint of the onion request explicitly allows raw utf-8 characters in
+# the path.  For direct requests, however, you should use the raw unicode value in the signature,
+# but URL-encode the value in the actual HTTP request path.
+#
 # NB: legacy sogs endpoints (that is: endpoint paths without a leading /) require specifying the
 # path in the signature message as `/legacy/whatever` even if just `whatever` is being used in the
 # onion request "endpoint" parameter).

--- a/sogs/routes/messages.py
+++ b/sogs/routes/messages.py
@@ -554,9 +554,12 @@ def message_react(room, msg_id, reaction):
     - `msg_id` — The message ID on which the reaction should be applied.  The message must be in
       this room, must not be deleted, and must be a regular message (i.e. not a whisper).
 
-    - `reaction` — The reaction to be added, as a UTF-8 string. It is recommended to use a
-      URL-encoded UTF-8 byte sequence (e.g. `%f0%9f%8d%86` for `🍆`); many HTTP libraries will do
-      this encoding automatically.
+    - `reaction` — The reaction to be added, as a UTF-8 string. When making a direct HTTP request it
+      is strongly recommended to use a URL-encoded UTF-8 byte sequence (e.g. `%f0%9f%8d%86` for
+      `🍆`); many HTTP libraries will do this encoding automatically.  When making an onion request
+      you can use the UTF-8 value directly in the path if that is simpler than URL-encoding.  Note
+      that regardless of whether URL-encoding is used or not, the X-SOGS-Signature value must sign
+      the unencoded value (i.e. `🍆` not `%f0%9f%8d%86`).
 
     # JSON parameters
 
@@ -597,9 +600,7 @@ def message_unreact(room, msg_id, reaction):
     - `msg_id` — The message ID from which the reaction should be removed.  The message must be in
       this room, must not be deleted, and must be a regular message (i.e. not a whisper).
 
-    - `reaction` — The UTF-8 reaction string. It is recommended to use a URL-encoded UTF-8 byte
-      sequence (e.g. `%f0%9f%8d%86` for `🍆`); many HTTP libraries will do this encoding
-      automatically.
+    - `reaction` — The UTF-8 reaction string.  See the PUT endpoint for encoding information.
 
     # Return value
 
@@ -637,9 +638,8 @@ def message_delete_reactions(room, msg_id, reaction=None):
       this room, must not be deleted, and must be a regular message (i.e. not a whisper).
 
     - `reaction` — The optional UTF-8 reaction string. If specified then all reactions of this type
-      are removed; if omitted then *all* reactions are removed from the post.  It is recommended to
-      use a URL-encoded UTF-8 byte sequence (e.g. `%f0%9f%8d%86` for `🍆`); many HTTP libraries will
-      do this encoding automatically.
+      are removed; if omitted then *all* reactions are removed from the post.  See the PUT endpoint
+      for encoding information.
 
     # Return value
 
@@ -668,9 +668,7 @@ def message_get_reactors(room, msg_id, reaction):
     - `msg_id` — The message ID in this room for which reactions are being queried.  The message
       must be in this room, must not be deleted, and must be a regular message (i.e. not a whisper).
 
-    - `reaction` — The UTF-8 reaction string. It is recommended to use a URL-encoded UTF-8 byte
-      sequence (e.g. `%f0%9f%8d%86` for `🍆`); many HTTP libraries will do this encoding
-      automatically.
+    - `reaction` — The UTF-8 reaction string.  See the PUT endpoint for encoding information.
 
     # Query Parameters
 

--- a/sogs/routes/onion_request.py
+++ b/sogs/routes/onion_request.py
@@ -120,6 +120,11 @@ def handle_v4_onionreq_plaintext(body):
     needs to be accessed through a v4 request for some reason then it can be accessed via the
     "/legacy/whatever" endpoint).
 
+    If an "endpoint" contains unicode characters then it is recommended to provide it as direct
+    UTF-8 values (rather than URL-encoded UTF-8).  Both approaches will work, but the X-SOGS-*
+    authentication headers will always apply on the final, URL-decoded value and so avoiding
+    URL-encoding in the first place will typically simplify client implementations.
+
     The "headers" field typically carries X-SOGS-* authentication headers as well as fields like
     Content-Type.  Note that, unlike v3 requests, the Content-Type does *not* have any default and
     should also be specified, often as `application/json`.  Unlike HTTP requests, Content-Length is

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -5,6 +5,7 @@ import time
 from sogs.hashing import blake2b, sha512
 import nacl.bindings as sodium
 from nacl.utils import random
+import urllib.parse
 
 import sogs.utils
 import sogs.crypto
@@ -24,6 +25,7 @@ def x_sogs_raw(
     b64_nonce: bool = True,
     blinded: bool = False,
     timestamp_off: int = 0,
+    nonce: bytes = None,
 ):
     """
     Calculates X-SOGS-* headers.
@@ -32,7 +34,7 @@ def x_sogs_raw(
 
     Use x_sogs(...) instead if you don't need the nonce/timestamp/signature values.
     """
-    n = x_sogs_nonce()
+    n = nonce if nonce else x_sogs_nonce()
     ts = int(time.time()) + timestamp_off
 
     if blinded:
@@ -45,6 +47,9 @@ def x_sogs_raw(
         pubkey = '15' + kA.hex()
     else:
         pubkey = '00' + s.verify_key.encode().hex()
+
+    if '%' in full_path:
+        full_path = urllib.parse.unquote(full_path)
 
     to_sign = [B.encode(), n, str(ts).encode(), method.encode(), full_path.encode()]
     if body:


### PR DESCRIPTION
Unicode paths (as added for reactions) are getting handled a bit wrong:

- For direct requests we see the final, URL-decoded value but not the
  actual encoded value the client used, and so if a client uses and
  signs the request for path `.../%F0%9F%8D%8D` what we see for path
  internally is `.../🍍` and so signature fails.

- The client might directly request `.../🍍`, however, in which case
  signature passes.

- Onion request endpoints were not properly decoding %xx escapes in the
  endpoint path, so the reactions endpoint would get a literal
  "%F0%9F%8D%8D" value as the reaction, which is wrong.

- Onion requests were *not* permitting unicode paths, however
  (attempting to do so hits an internal werkzeug error), so this can't
  be worked around nicely without an update.

This PR addresses the above with these fixes:

- Signatures now *always* apply to the final, URL-decode path, which
  means if a client is requesting `.../%F0%9F%8D%8D` they must use
  `.../🍍` in the signature.  This is pretty much necessary because the
  URL-encoding isn't unique and might get changed to some equivalent
  encoding by some intermediate proxy, which means we have no reliable
  way to know the exact escaped value the original client used.

- Internal subrequests (onion requests, batch requests) now properly
  understand both URL-encoded endpoints such as
  `"endpoint": "/foo/%F0%9F%8D%8D"`, and raw unicode endpoints such as
  `"endpoint": "/foo/🍍"`.  Both requests go to the same place (/foo/🍍) and the
  endpoint gets the proper "🍍" string regardless of which was used.

- Onion request signatures need to account for the decoded value, i.e.
  if using `%F0%9F%8D%8D` in the `endpoint` value then they need to
  construct the X-SOGS-Signature value using `🍍` in the PATH, not the
  `%xx`-escaped version.

  However, because onion requests now work fine with literal utf-8
  paths, it may be easier for onion requesting clients to simply use
  unicode literals in the onion request and forget about URL-encoding.
  This isn't required -- URL-encoding will still work, as long as the
  signature isn't applied to the URL-encoded path.

  Direct requests, however, including requests over lokinet (in the
  future), must still take care to URL-encode the path, since external
  proxy servers may be involved in passing along such a request which
  might not be happy with raw characters in an HTTP request path.