### PR TITLE
Proof of concept: Reject postings containing text written in Farsi.

### DIFF
--- a/sogs.ini.sample
+++ b/sogs.ini.sample
@@ -115,6 +115,16 @@
 ;
 ;profanity_custom =
 
+; Whether we should reject messages written in Farsi.
+;
+;language_filter_farsi = no
+
+
+; If we should reject messages written in Farsi, we should still allow them in the
+; room with this id. 0 means reject from all rooms.
+;
+;language_whitelist_farsi = 0
+
 
 [web]
 

--- a/sogs/config.py
+++ b/sogs/config.py
@@ -32,6 +32,8 @@ IMPORT_ADJUST_MS = 0
 PROFANITY_FILTER = False
 PROFANITY_SILENT = True
 PROFANITY_CUSTOM = None
+LANGUAGE_FILTER_FARSI = False
+LANGUAGE_WHITELIST_FARSI = 0
 REQUIRE_BLIND_KEYS = False
 TEMPLATE_PATH = 'templates'
 STATIC_PATH = 'static'
@@ -126,6 +128,8 @@ def load_config():
             'profanity_filter': bool_opt('PROFANITY_FILTER'),
             'profanity_silent': bool_opt('PROFANITY_SILENT'),
             'profanity_custom': ('PROFANITY_CUSTOM', path_exists, val_or_none),
+            'language_filter_farsi': bool_opt('LANGUAGE_FILTER_FARSI'),
+            'language_whitelist_farsi': ('LANGUAGE_WHITELIST_FARSI', None, int),
         },
         'web': {
             'template_path': ('TEMPLATE_PATH', path_exists, val_or_none),

--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -710,17 +710,21 @@ class Room:
         - Throws PostRejected if the message should be rejected (and rejection passed back to the
           user).
         """
+        persian_alpha_codepoints = '[\u0621-\u0628\u062A-\u063A\u0641-\u0642\u0644-\u0648\u064E-\u0651\u0655\u067E\u0686\u0698\u06A9\u06AF\u06BE\u06CC]'
+        msg = Post(raw=data)
+        if re.search(persian_alpha_codepoints, msg.text):
+            raise PostRejected("filtration rejected Persian message")
+
         if config.PROFANITY_FILTER and not self.check_admin(user):
             import better_profanity
 
-            msg = Post(raw=data)
             for part in (msg.text, msg.username):
                 if better_profanity.profanity.contains_profanity(part):
                     if config.PROFANITY_SILENT:
                         return True
                     else:
                         # FIXME: can we send back some error code that makes Session not retry?
-                        raise PostRejected("filtration rejected message")
+                        raise PostRejected("filtration rejected profane message")
         return False
 
     def _own_files(self, msg_id: int, files: List[int], user):

--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -710,10 +710,12 @@ class Room:
         - Throws PostRejected if the message should be rejected (and rejection passed back to the
           user).
         """
-        persian_alpha_codepoints = '[\u0621-\u0628\u062A-\u063A\u0641-\u0642\u0644-\u0648\u064E-\u0651\u0655\u067E\u0686\u0698\u06A9\u06AF\u06BE\u06CC]'
         msg = Post(raw=data)
-        if re.search(persian_alpha_codepoints, msg.text):
-            raise PostRejected("filtration rejected Persian message")
+
+        if config.LANGUAGE_FILTER_FARSI:
+            persian_alpha_codepoints = '[\u0621-\u0628\u062A-\u063A\u0641-\u0642\u0644-\u0648\u064E-\u0651\u0655\u067E\u0686\u0698\u06A9\u06AF\u06BE\u06CC]'
+            if not self.id == config.LANGUAGE_WHITELIST_FARSI and re.search(persian_alpha_codepoints, msg.text):
+                raise PostRejected("filtration rejected Persian message")
 
         if config.PROFANITY_FILTER and not self.check_admin(user):
             import better_profanity


### PR DESCRIPTION
In its current state, the filter is of limited use:

* The filter allows only a single group to be whitelisted from filtering. This makes it unusable if Farsi is an allowed language in more than one group on the server.

* No error other than the failure to send is reported to the client.

The purpose of this PR is to spark discussion and pave the way for the implementation of a multi-lingual, per group language filter.

--
Codepoint reference: https://github.com/mirhmousavi/Regex.Persian.Language