### PR TITLE
Filter responses and more filtering control

### DIFF
--- a/sogs.ini.filter-sample
+++ b/sogs.ini.filter-sample
@@ -1,0 +1,119 @@
+; This file describes the settings you can use for advanced filtering controls.
+;
+; Note that when configuring this, it does *not* go in a separate file but rather in your active
+; sogs.ini configuration file.  (Since everything goes here in a separate section, it doesn't matter
+; where in sogs.ini you add it).
+
+
+;
+; Room-specific filtering
+;
+; To set filtration rules for a specific room you add a [room:TOKEN] section and then set the
+; rules that should apply to this specific room.  For example, to enable the profanity filter and
+; disallow (only) cyrillic characters in the room with token 'sudoku' you would add:
+;
+;[room:sudoku]
+;profanity_filter=yes
+;profanity_silent=yes
+;alphabet_filters=cyrillic
+;
+; This overrides the default from the main [messages] config section for any given keys, so it can
+; be used to replace or change the rules that apply to a given room.  Currently only the
+; profanity_filter, profanity_silent, alphabet_filters can be overridden in this way.
+
+;
+; Filtration responses
+;
+; When a message is filtered because of the profanity or alphabet filtrations SOGS can optionally
+; send a reply in the room; this reply can either be visible to everyone, or just to the specific
+; user.  To enable such a reply, add a filter section here: the section name consists of
+; 'filter:TYPE:ROOM' where TYPE and ROOM are the filtration type and room token, or '*' to match all
+; types/rooms.
+;
+; Section names for all filtered messages:
+;[filter:*:*]
+;
+; Section names for a particular filtration type:
+;[filter:*:profanity]
+;[filter:*:alphabet]
+;
+; The "type" can also be a specific language:
+;[filter:*:arabic]
+;[filter:*:cyrillic]
+; etc.
+;
+; Room-specific filtration section names:
+;
+;[filter:fishing:*]
+;[filter:sudoku:profanity]
+;
+; If using both '*' and specific values, the value from the more specific section will be used where
+; present.
+;
+; Within this section there are currently three settings:
+;
+; - reply -- the body of a reply to send (see details below).  If omitted or empty then no reply
+;   will be sent.
+; - profile_name -- the profile name to use in that reply.
+; - public -- whether the reply should be seen by everyone or just the poster.  The default is 'no'
+;   (i.e. only the user will see the reply).
+;
+; The `reply` value should be specified on a single line of the config, and supports the following
+; substitutions:
+;
+; \@ - the profile name, in @tag form, of the poster whose message was declined.
+; \p - the profile name in plain text.
+; \r - the name of the room
+; \t - the token of the room
+; \n - a line break
+; \\ - a literal \ character
+;
+; You can also randomize among multiple responses by specifying multiple lines in the config: each
+; additional line must be indented in the .ini file to be properly recognized.
+;
+; For example if you use this config:
+;
+
+[messages]
+profanity_filter=yes
+profanity_silent=yes
+alphabet_filters=arabic cyrillic
+alphabet_silent=yes
+
+[room:sailors]
+profanity_filter=no
+
+[filter:*:*]
+profile_name=LanguagePolice
+reply=Hi \@, I'm afraid your message couldn't be sent: \r is English-only!
+
+[filter:*:profanity]
+profile_name=Swear Jar
+reply=Whoa there, \@!  That language is too strong for the \r group!  Try the Sailors group instead.
+
+[filter:sudoku:profanity]
+profile_name=Bot45
+public=yes
+reply=\@ got a little too enthusiastic today with their solve.  Maybe someone can assist?
+ Uh oh, I think \@ has two ３s in the same row!
+ I think \@'s sudoku broke 😦
+
+; then arabic/cyrillic/person would be blocked everywhere, profanity would be blocked everywhere
+; except the 'sailors' room, and when a message is blocked you would get a message such as one of
+; the following depending on the room and the rule applied:
+;
+;
+; (LanguagePolice)
+; Hi @Foreignsailor1988, I'm afraid your message couldn't be set: Salty Sailors is English-only!
+;
+;
+; (Swear Jar)
+; Whoa there @87yearoldgrandma!  That language is too strong for the Cuddly Kittens group!  Try the Sailors group instead.
+;
+;
+; (Bot45); [one of the following would be sent randomly, visible to everyone in the group]
+; @87yearoldgrandma got a little too enthusiastic today with their solve.  Maybe someone can assist?
+;
+; Uh oh, I think @87yearoldgrandma has two ３s in the same row!
+;
+; I think @87yearoldgrandma's sudoku broke 😦

--- a/sogs.ini.sample
+++ b/sogs.ini.sample
@@ -115,6 +115,20 @@
 ;
 ;profanity_custom =
 
+; Whether we should reject messages that use a particular alphabet.
+;
+;alphabet_filters = [ arabic, cyrillic, persian ]
+;alphabet_filters = []
+
+
+; If we reject messages written in a given alphabet, we should still allow them in
+; specific rooms. A list of whitelisted room ids can be given here, as returned by
+; `SELECT * FROM rooms;`. An empty list means to reject from all rooms.
+;
+;alphabet_whitelist_arabic = []
+;alphabet_whitelist_cyrillic = []
+;alphabet_whitelist_persian = []
+
 
 [web]
 

--- a/sogs.ini.sample
+++ b/sogs.ini.sample
@@ -93,8 +93,7 @@
 
 
 ; Whether we should pass words through a profanity filter, rejecting messages that contain profane
-; words (and common permutations of those words).  (Note that profanity filters are never applied to
-; room or server admins).
+; words (and common permutations of those words).
 ;
 ;profanity_filter = no
 
@@ -115,19 +114,31 @@
 ;
 ;profanity_custom =
 
-; Whether we should reject messages that use a particular alphabet.
+; Whether we should reject messages that use a particular alphabet.  This is a space or
+; comma-separated list of alphabet names; posts with characters in the given language ranges will be
+; blocked (unless posted by a mod/admin).  Currently supported are: arabic, cyrillic, and persian
+; (note that persian is included within arabic).
 ;
-;alphabet_filters = [ arabic, cyrillic, persian ]
-;alphabet_filters = []
+; *This* setting is the default setting for all rooms, but you can also make room-specific filtering
+; (see sogs.ini.filter-sample for details).
+;
+;alphabet_filters =
 
 
-; If we reject messages written in a given alphabet, we should still allow them in
-; specific rooms. A list of whitelisted room ids can be given here, as returned by
-; `SELECT * FROM rooms;`. An empty list means to reject from all rooms.
+; Whether the alphabet filter should silently drop (true) or return an error (false).
 ;
-;alphabet_whitelist_arabic = []
-;alphabet_whitelist_cyrillic = []
-;alphabet_whitelist_persian = []
+;alphabet_silent = yes
+
+
+; Whether the above filters should be applied to moderators and admins (=yes) or not (=no).  The
+; default is no, that is, mods and admins messages are not filtered by default.
+;
+;filter_mods = no
+
+
+; The profanity and alphabet filters can be controlled on a per-room setting (which overrides the
+; global default set above) and can have automated responses sent by the SOGS server.  For details
+; and examples see the sogs.ini.filter-sample file.
 
 
 [web]

--- a/sogs/config.py
+++ b/sogs/config.py
@@ -32,6 +32,10 @@ IMPORT_ADJUST_MS = 0
 PROFANITY_FILTER = False
 PROFANITY_SILENT = True
 PROFANITY_CUSTOM = None
+ALPHABET_FILTERS = []
+ALPHABET_WHITELIST_ARABIC = []
+ALPHABET_WHITELIST_CYRILLIC = []
+ALPHABET_WHITELIST_PERSIAN = []
 REQUIRE_BLIND_KEYS = False
 TEMPLATE_PATH = 'templates'
 STATIC_PATH = 'static'
@@ -83,6 +87,12 @@ def load_config():
     def days_to_seconds_or_none(v):
         return days_to_seconds(v) if v else None
 
+    def list_of_strs(v):
+        return re.split('[,\s]+', value[1:-1].strip())
+
+    def list_of_ints(v):
+        return [int(i) for i in list_of_strs(v)]
+
     truthy = ('y', 'yes', 'Y', 'Yes', 'true', 'True', 'on', 'On', '1')
     falsey = ('n', 'no', 'N', 'No', 'false', 'False', 'off', 'Off', '0')
     booly = truthy + falsey
@@ -126,6 +136,10 @@ def load_config():
             'profanity_filter': bool_opt('PROFANITY_FILTER'),
             'profanity_silent': bool_opt('PROFANITY_SILENT'),
             'profanity_custom': ('PROFANITY_CUSTOM', path_exists, val_or_none),
+            'alphabet_filters': ('ALPHABET_FILTERS', None, list_of_strs),
+            'alphabet_whitelist_arabic': ('ALPHABET_WHITELIST_ARABIC', None, list_of_ints),
+            'alphabet_whitelist_cyrillic': ('ALPHABET_WHITELIST_CYRILLIC', None, list_of_ints),
+            'alphabet_whitelist_persian': ('ALPHABET_WHITELIST_PERSIAN', None, list_of_ints),
         },
         'web': {
             'template_path': ('TEMPLATE_PATH', path_exists, val_or_none),

--- a/sogs/crypto.py
+++ b/sogs/crypto.py
@@ -72,11 +72,11 @@ def verify_sig_from_pk(data, sig, pk):
     return VerifyKey(pk).verify(data, sig)
 
 
-_server_signkey = SigningKey(_privkey_bytes)
+server_signkey = SigningKey(_privkey_bytes)
+server_verifykey = server_signkey.verify_key
 
-server_verify = _server_signkey.verify_key.verify
-
-server_sign = _server_signkey.sign
+server_verify = server_verifykey.verify
+server_sign = server_signkey.sign
 
 
 def server_encrypt(pk, data):

--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -793,7 +793,13 @@ class Room:
         - Throws PostRejected if the message should be rejected (and rejection passed back to the
           user).
         """
-        msg = Post(raw=data)
+        msg_ = None
+
+        def msg():
+            nonlocal msg_
+            if msg_ is None:
+                msg_ = Post(raw=data)
+            return msg_
 
         if not config.FILTER_MODS and self.check_moderator(user):
             return None
@@ -807,7 +813,7 @@ class Room:
             if lang not in alphabets:
                 continue
 
-            if not pattern.search(msg.text):
+            if not pattern.search(msg().text):
                 continue
 
             # Filter it!
@@ -817,7 +823,7 @@ class Room:
         if not filter_type and filt['profanity_filter']:
             import better_profanity
 
-            for part in (msg.text, msg.username):
+            for part in (msg().text, msg().username):
                 if better_profanity.profanity.contains_profanity(part):
                     filter_type = 'profanity'
                     break
@@ -831,7 +837,7 @@ class Room:
         if msg_fmt:
             pbmsg = protobuf.Content()
             body = msg_fmt.format(
-                profile_name=(user.session_id if msg.username is None else msg.username),
+                profile_name=(user.session_id if msg().username is None else msg().username),
                 profile_at="@" + user.session_id,
                 room_name=self.name,
                 room_token=self.token,

--- a/sogs/model/room.py
+++ b/sogs/model/room.py
@@ -1,10 +1,12 @@
-from .. import config, crypto, db, utils
+from .. import config, crypto, db, utils, session_pb2 as protobuf
 from ..db import query
+from ..hashing import blake2b
 from ..omq import send_mule
 from ..web import app
 from .user import User
 from .file import File
 from .post import Post
+from nacl.signing import SigningKey
 from .exc import (
     NoSuchRoom,
     NoSuchFile,
@@ -17,6 +19,7 @@ from .exc import (
 )
 
 import os
+import random
 import re
 import sqlalchemy.exc
 import time
@@ -27,6 +30,22 @@ from typing import Optional, Union, List
 # are carried over from old SOGS).
 rate_limit_size = 5
 rate_limit_interval = 16.0
+
+
+# Character ranges for different filters.  This is ordered because some are subsets of each other
+# (e.g. persian is a subset of the arabic character range).
+alphabet_filter_patterns = [
+    (
+        'persian',
+        re.compile(
+            r'[\u0621-\u0628\u062a-\u063a\u0641-\u0642\u0644-\u0648\u064e-\u0651\u0655'
+            r'\u067e\u0686\u0698\u06a9\u06af\u06be\u06cc]'
+        ),
+    ),
+    ('arabic', re.compile(r'[\u0600-\u06ff\u0750-\u077f\u08a0-\u08ff\ufb50-\ufdff\ufe70-\ufefe]')),
+    ('cyrillic', re.compile(r'[\u0400-\u04ff]')),
+]
+filter_privkeys = {}
 
 
 class Room:
@@ -697,48 +716,183 @@ class Room:
 
         return msgs
 
+    def filtering(self):
+        settings = {
+            'profanity_filter': config.PROFANITY_FILTER,
+            'profanity_silent': config.PROFANITY_SILENT,
+            'alphabet_filters': config.ALPHABET_FILTERS,
+            'alphabet_silent': config.ALPHABET_SILENT,
+        }
+        if self.token in config.ROOM_OVERRIDES:
+            for k in (
+                'profanity_filter',
+                'profanity_silent',
+                'alphabet_filters',
+                'alphabet_silent',
+            ):
+                if k in config.ROOM_OVERRIDES[self.token]:
+                    settings[k] = config.ROOM_OVERRIDES[self.token][k]
+        return settings
+
+    def filter_should_reply(self, filter_type, filter_lang):
+        """If the settings say we should reply to a filter, this returns a tuple of
+
+        (profile name, message format, whisper)
+
+        where profile name is the name we should use in the reply, message format is a string with
+        substitutions ready, and whisper is True/False depending on whether it should be whispered
+        to the user (True) or public (False).
+
+        If we shouldn't reply this returns (None, None, None)
+        """
+
+        if not config.FILTER_SETTINGS:
+            return (None, None, None)
+
+        reply_format = None
+        profile_name = 'SOGS'
+        public = False
+
+        # Precedences from least to most specific so that we load values from least specific first
+        # then overwrite them if we find a value in a more specific section
+        room_precedence = ('*', self.token)
+        filter_precedence = ('*', filter_type, filter_lang) if filter_lang else ('*', filter_type)
+
+        for r in room_precedence:
+            s1 = config.FILTER_SETTINGS.get(r)
+            if s1 is None:
+                continue
+            for f in filter_precedence:
+                settings = s1.get(f)
+                if settings is None:
+                    continue
+
+                rf = settings.get('reply')
+                pn = settings.get('profile_name')
+                pb = settings.get('public')
+                if rf is not None:
+                    reply_format = random.choice(rf)
+                if pn is not None:
+                    profile_name = pn
+                if pb is not None:
+                    public = pb
+
+        return (reply_format, profile_name, public)
+
     def should_filter(self, user: User, data: bytes):
         """
         Checks a message for disallowed alphabets and profanity (if the profanity
         filter is enabled).
 
-        - Returns False if this message passes (i.e. didn't trigger any filter, or is
+        - Returns None if this message passes (i.e. didn't trigger any filter, or is
           being posted by an admin to whom the filters don't apply).
 
-        Otherwise, depending on the filtering configuration:
-        - Returns True if this message should be silently accepted but filtered (i.e. not shown to
-          users).
+        - Returns a callback if the message fails but should be silently accepted.  The callback
+          should be called (with no arguments) *after* the filtered message is inserted into the db.
+
         - Throws PostRejected if the message should be rejected (and rejection passed back to the
           user).
         """
         msg = Post(raw=data)
 
-        if 'arabic' in config.ALPHABET_FILTERS and not self.check_admin(user):
-            arabic_alpha_codepoints = '[\u0600-\u06ff\u0750-\u077f\u08a0-\u08ff\ufb50-\ufdff\ufe70-\ufeff]'
-            if not self.id in config.ALPHABET_WHITELIST_ARABIC and re.search(arabic_alpha_codepoints, msg.text):
-                raise PostRejected("filtration rejected Arabic message")
+        if not config.FILTER_MODS and self.check_moderator(user):
+            return None
 
-        if 'cyrillic' in config.ALPHABET_FILTERS and not self.check_admin(user):
-            cyrillic_alpha_codepoints = '[\u0400-\u04ff]'
-            if not self.id in config.ALPHABET_WHITELIST_CYRILLIC and re.search(cyrillic_alpha_codepoints, msg.text):
-                raise PostRejected("filtration rejected Cyrillic message")
+        filter_type = None
+        filter_lang = None
 
-        if 'persian' in config.ALPHABET_FILTERS and not self.check_admin(user):
-            persian_alpha_codepoints = '[\u0621-\u0628\u062a-\u063a\u0641-\u0642\u0644-\u0648\u064e-\u0651\u0655\u067e\u0686\u0698\u06a9\u06af\u06be\u06cc]'
-            if not self.id in config.ALPHABET_WHITELIST_PERSIAN and re.search(persian_alpha_codepoints, msg.text):
-                raise PostRejected("filtration rejected Persian message")
+        filt = self.filtering()
+        alphabets = filt['alphabet_filters']
+        for lang, pattern in alphabet_filter_patterns:
+            if lang not in alphabets:
+                continue
 
-        if config.PROFANITY_FILTER and not self.check_admin(user):
+            if not pattern.search(msg.text):
+                continue
+
+            # Filter it!
+            filter_type, filter_lang = 'alphabet', lang
+            break
+
+        if not filter_type and filt['profanity_filter']:
             import better_profanity
 
             for part in (msg.text, msg.username):
                 if better_profanity.profanity.contains_profanity(part):
-                    if config.PROFANITY_SILENT:
-                        return True
-                    else:
-                        # FIXME: can we send back some error code that makes Session not retry?
-                        raise PostRejected("filtration rejected profane message")
-        return False
+                    filter_type = 'profanity'
+                    break
+
+        if not filter_type:
+            return None
+
+        silent = filt[filter_type + '_silent']
+
+        msg_fmt, prof_name, pub = self.filter_should_reply(filter_type, filter_lang)
+        if msg_fmt:
+            pbmsg = protobuf.Content()
+            body = msg_fmt.format(
+                profile_name=(user.session_id if msg.username is None else msg.username),
+                profile_at="@" + user.session_id,
+                room_name=self.name,
+                room_token=self.token,
+            ).encode()
+            pbmsg.dataMessage.body = body
+            pbmsg.dataMessage.timestamp = int(time.time() * 1000)
+            pbmsg.dataMessage.profile.displayName = prof_name
+
+            # Add two bytes padding so that session doesn't get confused by a lack of padding
+            pbmsg = pbmsg.SerializeToString() + b'\x80\x00'
+
+            # Make a fake signing key based on prof_name and the server privkey (so that different
+            # names use different keys; otherwise the bot names overwrite each other in Session
+            # clients when a later message has a new profile name).
+            global filter_privkeys
+            if prof_name in filter_privkeys:
+                signingkey = filter_privkeys[prof_name]
+            else:
+                signingkey = SigningKey(
+                    blake2b(
+                        prof_name.encode() + crypto.server_signkey.encode(), key=b'sogsfiltering'
+                    )
+                )
+                filter_privkeys[prof_name] = signingkey
+
+            sig = signingkey.sign(pbmsg).signature
+            server_fake_user = User(
+                session_id='15' + signingkey.verify_key.encode().hex(), autovivify=True, touch=False
+            )
+
+            def insert_reply():
+                query(
+                    """
+                    INSERT INTO messages
+                        (room, "user", data, data_size, signature, whisper)
+                        VALUES
+                        (:r, :u, :data, :data_size, :signature, :whisper)
+                    """,
+                    r=self.id,
+                    u=server_fake_user.id,
+                    data=pbmsg[:-2],
+                    data_size=len(pbmsg),
+                    signature=sig,
+                    whisper=None if pub else user.id,
+                )
+
+            if filt[filter_type + '_silent']:
+                # Defer the insertion until after the filtered row gets inserted
+                return insert_reply
+            else:
+                insert_reply()
+
+        elif silent:
+            # No reply, so just return an empty callback
+            def noop():
+                pass
+
+            return noop
+
+        # FIXME: can we send back some error code that makes Session not retry?
+        raise PostRejected(f"filtration rejected message ({filter_type})")
 
     def _own_files(self, msg_id: int, files: List[int], user):
         """
@@ -837,7 +991,7 @@ class Room:
                 data=unpadded_data,
                 data_size=data_size,
                 signature=sig,
-                filtered=filtered,
+                filtered=filtered is not None,
                 whisper=whisper_to.id if whisper_to else None,
                 whisper_mods=whisper_mods,
             )
@@ -857,11 +1011,19 @@ class Room:
                 'signature': sig,
                 'reactions': {},
             }
+            if filtered is not None:
+                msg['filtered'] = True
             if whisper_to or whisper_mods:
                 msg['whisper'] = True
                 msg['whisper_mods'] = whisper_mods
                 if whisper_to:
                     msg['whisper_to'] = whisper_to.session_id
+
+        # Don't call this inside the transaction because, if it's inserting a reply, we want the
+        # reply to have a later timestamp for proper ordering (because the timestamp inside a
+        # transaction is the time when the transaction started).
+        if filtered is not None:
+            filtered()
 
         send_mule("message_posted", msg['id'])
         return msg
@@ -903,9 +1065,10 @@ class Room:
             if author != user.id:
                 raise BadPermission()
 
-            if filtered:
+            if filtered is not None:
                 # Silent filtering is enabled and the edit failed the filter, so we want to drop the
                 # actual post update.
+                filtered()
                 return
 
             data_size = len(data)


### PR DESCRIPTION
This builds off PR https://github.com/oxen-io/session-pysogs/pull/129 for language filtering, but revamps how languages are specified and overridden with a mechanism that we can use in the future for other room-specific settings, and that doesn't rely on room ids (but rather tokens).

Most notably, this PR (in addition to the language filtering added in #129) adds an ability to send responses to filtered messages either back to (just) the user who sent them (via a whisper), or to the whole room.

This allows configuration of the message (or multiple messages, for random selection), profile name, and uses a (simple) templating mechanism for the message so that you can (somewhat) personalize it for the user.

Other changes included here:

- You can now control whether or not mods/admins are affected by filtering via a new `filter_mods` setting.  (This is particularly useful for testing, but SOGS operators might also want to restrain their mods).

- profanity filtering can be room specific.

- alphabet filtering can be room specific (revamping how PR https://github.com/oxen-io/session-pysogs/pull/129 did room-specific settings).

- alphabet filtering can be configurably silent or not, like profanity filtering.

- added a new, separate example .ini file showing how to set things up with room-specific settings.


Copying from the added `sogs.ini.filter-sample` file for the detail on how the room-specific settings and auto-reply get configured:
```ini
;
; Room-specific filtering
;
; To set filtration rules for a specific room you add a [room:TOKEN] section and then set the
; rules that should apply to this specific room.  For example, to enable the profanity filter and
; disallow (only) cyrillic characters in the room with token 'sudoku' you would add:
;
;[room:sudoku]
;profanity_filter=yes
;profanity_silent=yes
;alphabet_filters=cyrillic
;
; This overrides the default from the main [messages] config section for any given keys, so it can
; be used to replace or change the rules that apply to a given room.  Currently only the
; profanity_filter, profanity_silent, alphabet_filters can be overridden in this way.

;
; Filtration responses
;
; When a message is filtered because of the profanity or alphabet filtrations SOGS can optionally
; send a reply in the room; this reply can either be visible to everyone, or just to the specific
; user.  To enable such a reply, add a filter section here: the section name consists of
; 'filter:TYPE:ROOM' where TYPE and ROOM are the filtration type and room token, or '*' to match all
; types/rooms.
;
; Section names for all filtered messages:
;[filter:*:*]
;
; Section names for a particular filtration type:
;[filter:*:profanity]
;[filter:*:alphabet]
;
; The "type" can also be a specific language:
;[filter:*:arabic]
;[filter:*:cyrillic]
; etc.
;
; Room-specific filtration section names:
;
;[filter:fishing:*]
;[filter:sudoku:profanity]
;
; If using both '*' and specific values, the value from the more specific section will be used where
; present.
;
; Within this section there are currently three settings:
;
; - reply -- the body of a reply to send (see details below).  If omitted or empty then no reply
;   will be sent.
; - profile_name -- the profile name to use in that reply.
; - public -- whether the reply should be seen by everyone or just the poster.  The default is 'no'
;   (i.e. only the user will see the reply).
;
; The `reply` value should be specified on a single line of the config, and supports the following
; substitutions:
;
; \@ - the profile name, in @tag form, of the poster whose message was declined.
; \p - the profile name in plain text.
; \r - the name of the room
; \t - the token of the room
; \n - a line break
; \\ - a literal \ character
;
; You can also randomize among multiple responses by specifying multiple lines in the config: each
; additional line must be indented in the .ini file to be properly recognized.
;
; For example if you use this config:
;

[messages]
profanity_filter=yes
profanity_silent=yes
alphabet_filters=arabic cyrillic
alphabet_silent=yes

[room:sailors]
profanity_filter=no

[filter:*:*]
profile_name=LanguagePolice
reply=Hi \@, I'm afraid your message couldn't be sent: \r is English-only!

[filter:*:profanity]
profile_name=Swear Jar
reply=Whoa there, \@!  That language is too strong for the \r group!  Try the Sailors group instead.

[filter:sudoku:profanity]
profile_name=Bot45
public=yes
reply=\@ got a little too enthusiastic today with their solve.  Maybe someone can assist?
 Uh oh, I think \@ has two ３s in the same row!
 I think \@'s sudoku broke 😦

; then arabic/cyrillic/person would be blocked everywhere, profanity would be blocked everywhere
; except the 'sailors' room, and when a message is blocked you would get a message such as one of
; the following depending on the room and the rule applied:
;
;
; (LanguagePolice)
; Hi @Foreignsailor1988, I'm afraid your message couldn't be set: Salty Sailors is English-only!
;
;
; (Swear Jar)
; Whoa there @87yearoldgrandma!  That language is too strong for the Cuddly Kittens group!  Try the Sailors group instead.
;
;
; (Bot45); [one of the following would be sent randomly, visible to everyone in the group]
; @87yearoldgrandma got a little too enthusiastic today with their solve.  Maybe someone can assist?
;
; Uh oh, I think @87yearoldgrandma has two ３s in the same row!
;
; I think @87yearoldgrandma's sudoku broke 😦
```