### PR TITLE
Properly handle subrequest exceptions

### DIFF
--- a/sogs/model/exc.py
+++ b/sogs/model/exc.py
@@ -1,8 +1,3 @@
-from ..web import app
-from .. import http
-import flask
-
-
 class NotFound(LookupError):
     """Base class for NoSuchRoom, NoSuchFile, etc."""
 
@@ -84,24 +79,3 @@ class PostRateLimited(PostRejected):
 
     def __init__(self, msg=None):
         super().__init__("Rate limited" if msg is None else msg)
-
-
-# Map uncaught model exceptions into flask http exceptions
-@app.errorhandler(NotFound)
-def abort_bad_room(e):
-    flask.abort(http.NOT_FOUND)
-
-
-@app.errorhandler(BadPermission)
-def abort_perm_denied(e):
-    flask.abort(http.FORBIDDEN)
-
-
-@app.errorhandler(PostRejected)
-def abort_post_rejected(e):
-    flask.abort(http.TOO_MANY_REQUESTS)
-
-
-@app.errorhandler(InvalidData)
-def abort_invalid_data(e):
-    flask.abort(http.BAD_REQUEST)

--- a/sogs/routes/__init__.py
+++ b/sogs/routes/__init__.py
@@ -1,4 +1,5 @@
 from ..web import app
+
 from .legacy import legacy as legacy_endpoints
 from .general import general as general_endpoints
 from .onion_request import onion_request as onion_request_endpoints
@@ -7,6 +8,8 @@ from .messages import messages as messages_endpoints
 from .users import users as users_endpoints
 from .dm import dm as dm_endpoints
 from .views import views as views_endpoints
+
+from . import exc  # noqa: F401
 
 app.register_blueprint(dm_endpoints)
 app.register_blueprint(rooms_endpoints)

--- a/sogs/routes/exc.py
+++ b/sogs/routes/exc.py
@@ -1,0 +1,24 @@
+from ..web import app
+from .. import http
+from ..model import exc
+
+
+# Map uncaught model exceptions into flask http exceptions
+@app.errorhandler(exc.NotFound)
+def abort_bad_room(e):
+    return str(e), http.NOT_FOUND
+
+
+@app.errorhandler(exc.BadPermission)
+def abort_perm_denied(e):
+    return str(e), http.FORBIDDEN
+
+
+@app.errorhandler(exc.PostRejected)
+def abort_post_rejected(e):
+    return str(e), http.TOO_MANY_REQUESTS
+
+
+@app.errorhandler(exc.InvalidData)
+def abort_invalid_data(e):
+    return str(e), http.BAD_REQUEST

--- a/sogs/routes/subrequest.py
+++ b/sogs/routes/subrequest.py
@@ -95,7 +95,10 @@ def make_subrequest(
         app.logger.debug(f"Initiating sub-request for {method} {path}")
         g.user_reauth = user_reauth
         with app.request_context(subreq_env):
-            response = app.full_dispatch_request()
+            try:
+                response = app.full_dispatch_request()
+            except Exception as e:
+                response = app.make_response(app.handle_exception(e))
         if response.status_code >= 400:
             app.logger.warning(
                 f"Sub-request for {method} {path} returned status {response.status_code}"

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -1,6 +1,4 @@
-import pytest
 from sogs import db, utils
-import werkzeug.exceptions as wexc
 from request import sogs_get, sogs_post
 from util import pad64
 import time
@@ -553,8 +551,8 @@ def test_bans(client, room, room2, user, user2, mod, global_mod):
     r = sogs_post(client, url_ban, {'rooms': ['test-room']}, mod)
     assert r.status_code == 200
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/test-room/message", post, user)
+    r = sogs_post(client, "/room/test-room/message", post, user)
+    assert r.status_code == 403
 
     r = sogs_post(client, "/room/test-room/message", post, user2)
     assert r.status_code == 201
@@ -570,11 +568,11 @@ def test_bans(client, room, room2, user, user2, mod, global_mod):
     r = sogs_post(client, url_ban, {'rooms': ['*']}, global_mod)
     assert r.status_code == 200
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/test-room/message", post, user)
+    r = sogs_post(client, "/room/test-room/message", post, user)
+    assert r.status_code == 403
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/room2/message", post, user)
+    r = sogs_post(client, "/room/room2/message", post, user)
+    assert r.status_code == 403
 
     r = sogs_post(client, "/room/test-room/message", post, user2)
     assert r.status_code == 201
@@ -583,8 +581,8 @@ def test_bans(client, room, room2, user, user2, mod, global_mod):
 
     r = sogs_post(client, "/room/test-room/message", post, user)
     assert r.status_code == 201
-    with pytest.raises(wexc.Forbidden):
-        r = sogs_post(client, "/room/room2/message", post, user)
+    r = sogs_post(client, "/room/room2/message", post, user)
+    assert r.status_code == 403
 
     r = sogs_post(client, url_unban, {'rooms': ['*']}, global_mod)
 
@@ -641,11 +639,11 @@ def test_ban_timeouts(client, room, room2, user, mod, global_mod):
     r = sogs_post(client, url_ban, {'rooms': ['*'], 'timeout': 0.001}, global_mod)
     assert r.status_code == 200
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/test-room/message", post, user)
+    r = sogs_post(client, "/room/test-room/message", post, user)
+    assert r.status_code == 403
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/room2/message", post, user)
+    r = sogs_post(client, "/room/room2/message", post, user)
+    assert r.status_code == 403
 
     from sogs.cleanup import cleanup
 
@@ -660,8 +658,8 @@ def test_ban_timeouts(client, room, room2, user, mod, global_mod):
     r = sogs_post(client, url_ban, {'rooms': ['*'], 'timeout': 30}, mod)
     assert r.status_code == 200
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/test-room/message", post, user)
+    r = sogs_post(client, "/room/test-room/message", post, user)
+    assert r.status_code == 403
 
     r = sogs_post(client, "/room/room2/message", post, user)
     assert r.status_code == 201
@@ -669,8 +667,9 @@ def test_ban_timeouts(client, room, room2, user, mod, global_mod):
     # The timed ban shouldn't expire yet:
     assert cleanup() == (0, 0, 0, 0, 0)
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/test-room/message", post, user)
+    r = sogs_post(client, "/room/test-room/message", post, user)
+    assert r.status_code == 403
+
     r = sogs_post(client, "/room/room2/message", post, user)
     assert r.status_code == 201
 
@@ -683,8 +682,8 @@ def test_ban_timeouts(client, room, room2, user, mod, global_mod):
     r = sogs_post(client, url_ban, {'rooms': ['*'], 'timeout': 0.001}, mod)
     assert r.status_code == 200
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/test-room/message", post, user)
+    r = sogs_post(client, "/room/test-room/message", post, user)
+    assert r.status_code == 403
 
     time.sleep(0.002)
     assert cleanup() == (0, 0, 0, 1, 0)
@@ -717,8 +716,8 @@ def test_ban_timeouts(client, room, room2, user, mod, global_mod):
 
     assert cleanup() == (0, 0, 0, 0, 0)
 
-    with pytest.raises(wexc.Forbidden):
-        sogs_post(client, "/room/test-room/message", post, user)
+    r = sogs_post(client, "/room/test-room/message", post, user)
+    assert r.status_code == 403
 
     # Unbanning should remove the ban future
     assert sogs_post(client, url_unban, {'rooms': ['*']}, mod).status_code == 200


### PR DESCRIPTION
We weren't passing exceptions through the flask exception translation layer, so we'd end up with extra verbose logging when *desired* exceptions (like BadPermission) get raised, rather than handle and building those into a proper subrequest error response.

Fixes #132 