### PR TITLE
Log only HTTP errors for much less verbose logging.

### DIFF
--- a/contrib/uwsgi-sogs-proxied-socket.ini
+++ b/contrib/uwsgi-sogs-proxied-socket.ini
@@ -47,3 +47,6 @@ enable-threads = true
 manage-script-name = true
 mount = /=sogs.web:app
 mule = sogs.mule:run
+log-4xx = true
+log-5xx = true
+disable-logging = true

--- a/contrib/uwsgi-sogs-proxied.ini
+++ b/contrib/uwsgi-sogs-proxied.ini
@@ -54,3 +54,6 @@ enable-threads = true
 manage-script-name = true
 mount = /=sogs.web:app
 mule = sogs.mule:run
+log-4xx = true
+log-5xx = true
+disable-logging = true

--- a/contrib/uwsgi-sogs-standalone.ini
+++ b/contrib/uwsgi-sogs-standalone.ini
@@ -28,3 +28,6 @@ enable-threads = true
 http = :80
 mount = /=sogs.web:app
 mule = sogs.mule:run
+log-4xx = true
+log-5xx = true
+disable-logging = true


### PR DESCRIPTION
Logging the RPC endpoints seems pointless and creates a lot of noise, which obscures the messages that are actually of interest.

Fixes #148.