### PR TITLE
Include Session ids of admins and mods in -L|--list-rooms output.

### DIFF
--- a/sogs/__main__.py
+++ b/sogs/__main__.py
@@ -218,6 +218,7 @@ def print_room(room: Room):
         "+" if room.default_accessible else "-",
     )
 
+    nl = "\n"  + ' ' * 20
     print(
         f"""
 {room.token}
@@ -230,7 +231,12 @@ Attachments: {files} ({files_size:.1f} MB)
 Reactions: {r_total}; top 5: {', '.join(f"{r} ({c})" for r, c in reactions[0:5])}
 Active users: {active[0]} (1d), {active[1]} (7d), {active[2]} (14d), {active[3]} (30d)
 Default permissions: {perms}
-Moderators: {admins} admins ({len(ha)} hidden), {mods} moderators ({len(hm)} hidden)""",
+Moderators: {admins} admins ({len(ha)} hidden), {mods} moderators ({len(hm)} hidden)
+--
+Visible admins:     {nl.join(f"{admin}" for admin in a)}
+Hidden admins:      {nl.join(f"{admin}" for admin in ha)}
+Visible moderators: {nl.join(f"{mod}" for mod in m)}
+Hidden moderators:  {nl.join(f"{mod}" for mod in hm)}""",
         end='',
     )
     if args.verbose and any((m, a, hm, ha)):


### PR DESCRIPTION
I often find myself wanting to know who the admins/mods of a particular group are.

This changes the output to look like this:

```
...
Messages: 194 (0.1 MB)
Attachments: 79 (51.4 MB)
Reactions: 147; top 5: ✌️ (36), 👍 (33), 👌 (21), 💙 (19), 👏 (15)
Active users: 516 (1d), 1057 (7d), 1446 (14d), 2590 (30d)
Default permissions: +read, +write, +upload, +accessible
Moderators: 4 admins (0 hidden), 0 moderators (0 hidden)
--
Visible admins:     05xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
                    05xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
                    05xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
                    05xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Hidden admins:
Visible moderators:
Hidden moderators:
```