### PR TITLE
Fix room deletion when a room has reactions

### DIFF
--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -4,6 +4,7 @@ import sogs.model.exc as exc
 from sogs.model.room import Room, get_rooms
 from sogs.model.file import File
 from sogs import config
+from request import sogs_put
 from util import pad64, from_now
 
 
@@ -62,6 +63,20 @@ def test_delete(room, room2):
     rooms = get_rooms()
     assert len(rooms) == 1
     assert rooms[0].token == 'test-room'
+
+
+def test_delete_populated(room, room2, user, client):
+    assert len(get_rooms()) == 2
+
+    # Tests a bug where room deletion would fail if the room had reactions
+    m = room.add_post(user, "data 1".encode(), pad64("sig 1"))
+    r = sogs_put(client, f"/room/{room.token}/reaction/{m['id']}/🍆", {}, user)
+    assert r.status_code == 200
+    room.delete()
+
+    rooms = get_rooms()
+    assert len(rooms) == 1
+    assert rooms[0].token == 'room2'
 
 
 def test_info(room):


### PR DESCRIPTION
Room deletion wasn't working because there isn't a cascade on the foreign key from user_reactions -> reactions, and so deleting a room with reactions present would fail.  This first removes all the user_reactions to fix it.

(This lack of cascading delete here is intentional: typically, you aren't supposed to delete from the reactions end, but rather from the user_reactions end with removal of a `reaction` being automatically triggered once there are no more referencing user_reactions).

Includes a test (which is confirmed broken without the fix included here).