### PR TITLE
Add `/rooms/all/<SessionID:sid>` for server-wide message deletion.

### DIFF
--- a/sogs/routes/users.py
+++ b/sogs/routes/users.py
@@ -293,7 +293,7 @@ def ban_user(sid):
 
     The user's messages are not deleted by this request.  In order to ban and delete all messages
     use the [`/sequence`](#post-sequence) endpoint to bundle a `/user/.../ban` with a
-    [`/user/.../deleteMessages`](#post-usersiddeleteMessages) request.
+    [`/rooms/all/...`](#delete-roomsallsid) request.
 
     # Return value
 


### PR DESCRIPTION
This causes all messages by the given Session id to be deleted from the server. The deleting user must be a global moderator on the server.

This facility is needed to allow a server-wide 'Ban and Delete' feature for Session moderators and admins.