### PR TITLE
Add support for room-wide and server-wide deletion of a user's emoji reactions.

### DIFF
--- a/contrib/uwsgi-sogs-standalone.ini
+++ b/contrib/uwsgi-sogs-standalone.ini
@@ -25,7 +25,7 @@ gid = GROUP
 plugins = python3,http
 processes = 2
 enable-threads = true
-http = :80
+http-socket = [::]:80
 mount = /=sogs.web:app
 mule = sogs.mule:run
 log-4xx = true


### PR DESCRIPTION
This PR complements #167, which has already been merged.

Here, we add new endpoints to allow the deletion of a given user's emoji reactions from all messages in a given room, or from every room on the server.

`/room/<Room:room>/all/reactions/<SessionID:sid>` removes all reactions placed by the given user on messages in the specified room.

`/rooms/all/reactions/<SessionID:sid>` expands on this by removing all reactions by the given user from all rooms on the server.

As with message deletion, global moderator privileges are required for server-wide deletion.

The code has been tested and verified working on `sog.caliban.org`.

Care has been taken to incorporate in this pull-request the review feedback given in #167.