### PR TITLE
Prevent 404 requests to favicon.ico

### DIFF
--- a/sogs/templates/base.html
+++ b/sogs/templates/base.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title> sogs </title>
+    <link rel="icon" href="data:,">
   </head>
   <body>
     {% block body %}


### PR DESCRIPTION
Prevents failed request for favicon.ico resulting in 404 Not found error in server log lines (causing disk write and used space) and web browser requests.

Based on https://stackoverflow.com/a/38917888