### PR TITLE
Fix the ngnix proxy_pass pattern

### DIFF
--- a/debian/sogs-proxy.nginx.conf
+++ b/debian/sogs-proxy.nginx.conf
@@ -9,7 +9,7 @@ server {
     }
     location / {
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_pass http://127.3.2.1:4242$request_uri;
+        proxy_pass http://127.3.2.1:4242/;
     }
 
     listen 80;


### PR DESCRIPTION
Notes:

When use the ` http://127.3.2.1:4242$request_uri ` in the nginx config file `sogs-proxy`, it will redirect to a ERROR page ` http://127.3.2.1:4242/r/room_token ` by clicking the room link on the SOGS index web page.

When use the ` http://127.3.2.1:4242/ ` instead, it will redirect to ` http://example.com/r/room_token/ ` or ` http://<public_ip>/r/room_token `, and this works well for the SOGS index web accessing.

I just found, fixed and tested this issue recently!