### PR TITLE
Just correct the nginx config proxy_pass pattern in comments

### DIFF
--- a/contrib/uwsgi-sogs-proxied.ini
+++ b/contrib/uwsgi-sogs-proxied.ini
@@ -30,7 +30,7 @@
 #           proxy_set_header X-Real-IP $remote_addr;
 #           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 #           proxy_set_header Host $host;
-#           proxy_pass http://127.3.2.1:4242$request_uri;
+#           proxy_pass http://127.3.2.1:4242/;
 #       }
 #
 #       listen 80;


### PR DESCRIPTION
Notes:

When use the ` http://127.3.2.1:4242$request_uri ` in the nginx config file `sogs-proxy`, it will redirect to error page ` http://127.3.2.1:4242/r/room_token ` by clicking the room link on the SOGS index web page.

When use the ` http://127.3.2.1:4242/ ` instead, it will redirect to ` http://example.com/r/room_token/ ` or ` http://<public_ip>/r/room_token `, and this works well for the SOGS web accessing.

I also commited this fix and make a PR to the deb package building branch ` debian/sid `.