### PR TITLE
Also bind to the host's IPv6 address, if present.

### DIFF
--- a/contrib/uwsgi-sogs-standalone.ini
+++ b/contrib/uwsgi-sogs-standalone.ini
@@ -25,7 +25,7 @@ gid = GROUP
 plugins = python3,http
 processes = 2
 enable-threads = true
-http = :80
+http-socket = [::]:80
 mount = /=sogs.web:app
 mule = sogs.mule:run
 log-4xx = true


### PR DESCRIPTION
I also took the opportunity to migrate to the full parameter name, `http-socket`, since that's what `uwsgi-sogs-proxied.ini` uses.